### PR TITLE
Update to go-spiffe v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pires/go-proxyproto v0.0.0-20190615163442-2c19fd512994
 	github.com/prometheus/client_golang v1.7.1
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
-	github.com/spiffe/go-spiffe v0.0.0-20190922191205-018e7197ed1c
+	github.com/spiffe/go-spiffe v1.1.0
 	github.com/square/certigo v1.11.0
 	github.com/square/go-sq-metrics v0.0.0-20170531223841-ae72f332d0d9
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 h1:dY6ETXrvDG7
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/spiffe/go-spiffe v0.0.0-20190922191205-018e7197ed1c h1:wpwh25WjvKF8/+N+wMy1u9nMiOXfw5sqpmL5ZSAFIWU=
-github.com/spiffe/go-spiffe v0.0.0-20190922191205-018e7197ed1c/go.mod h1:HyNeJnVYkDyQgB2qcSPxVYkAA2F3lQu51bDxNpFcKxY=
+github.com/spiffe/go-spiffe v1.1.0 h1:4GCqq8teavqkCl2j3c/vxQDgr33JidVRVT3mfssR6oM=
+github.com/spiffe/go-spiffe v1.1.0/go.mod h1:HyNeJnVYkDyQgB2qcSPxVYkAA2F3lQu51bDxNpFcKxY=
 github.com/square/certigo v1.11.0 h1:JvLGOmbq/X1ohn/NyNfhhSuURjy8Y86kGxfcSF2wfHE=
 github.com/square/certigo v1.11.0/go.mod h1:p1H2U6xyGrh+kO/Zhi74zcLpLwaDkZo4NaxCK1kD2jw=
 github.com/square/go-sq-metrics v0.0.0-20170531223841-ae72f332d0d9 h1:EjCIkN8CnRBciDeOM2c+5uBd+ek5r90N6r6zWwLUXgo=


### PR DESCRIPTION
go-spiffe v1.1.0 contains a small change to the handling of federated trust domain bundles that brings it in line with the Workload API specification. Without the fix, it is possible for federation to be broken with future releases of SPIRE.