### PR TITLE
Don't force removal of Unix-domain sockets we don't own

### DIFF
--- a/main.go
+++ b/main.go
@@ -552,10 +552,8 @@ func clientListen(context *Context) error {
 		return err
 	}
 
-	// If this is a UNIX socket, make sure we cleanup files on close.
-	if ul, ok := listener.(*net.UnixListener); ok {
-		ul.SetUnlinkOnClose(true)
-	}
+	// If this is a UNIX socket, and we're listen()ing, default Go net
+	// behavior cleans up filesystem artifact automatically at close() .
 
 	p := proxy.New(
 		listener,

--- a/socket/net.go
+++ b/socket/net.go
@@ -87,7 +87,8 @@ func ParseHTTPAddress(input string) (https bool, address string) {
 // opened socket will be bound with SO_REUSEPORT.
 //
 // For 'unix' sockets, the address must be a path. The socket file
-// will be set to unlink on close automatically.
+// will be set to unlink on close automatically because it's Listen()ed
+// on, and thus owned by this process.
 //
 // For 'launchd' sockets, the address must be the name of the socket
 // from the plist file. Only one socket maybe configured in the
@@ -108,7 +109,6 @@ func Open(network, address string) (net.Listener, error) {
 		if err != nil {
 			return nil, err
 		}
-		listener.(*net.UnixListener).SetUnlinkOnClose(true)
 		return listener, nil
 	default:
 		return reuseport.NewReusablePortListener(network, address)


### PR DESCRIPTION
Go net library already does the right thing for removing sockets. It's
wrong to override it.

From net source:
// The default behavior is to unlink the socket file only when package
// net created it.  That is, when the listener and the underlying socket
// file were created by a call to Listen or ListenUnix, then by default
// closing the listener will remove the socket file.  but if the
// listener was created by a call to FileListener to use an already
// existing socket file, then by default closing the listener will not
// remove the socket file.

Closes: #333