### PR TITLE
Flags & docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ server. Multiple flags are treated as a logical disjunction (OR), meaning
 clients can connect as long as any of the flags matches. Ghostunnel is
 compatible with [SPIFFE][spiffe] [X.509 SVIDs][svid].
 
-Ghostunnel also has experimental support for [Open Policy Agent](https://www.openpolicyagent.org/) policies.
+Ghostunnel also has experimental support for [Open Policy
+Agent](https://www.openpolicyagent.org/) (OPA) policies.
 
 See [ACCESS-FLAGS](docs/ACCESS-FLAGS.md) for details.
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"github.com/open-policy-agent/opa/rego"
 	"net"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/ghostunnel/ghostunnel/wildcard"
+	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -135,6 +136,7 @@ func TestAuthorizeOPARejectCommonName(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.NotNil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "Rego policy on different CN should be rejected")
 }
@@ -154,6 +156,7 @@ func TestAuthorizeOPAAcceptCommonName(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "Rego policy validates CN should pass")
 }
@@ -175,6 +178,7 @@ func TestAuthorizeOPAAcceptDNSn(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "Rego policy validates testing DNS names")
 }
@@ -198,6 +202,7 @@ func TestAuthorizeOPAAcceptURIs(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "Rego policy validates testing URIs")
 }
@@ -219,6 +224,7 @@ func TestAuthorizeOPAAcceptOneOU(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "Rego policy validates one OU")
 }
@@ -240,6 +246,7 @@ func TestAuthorizeOPARejectAllOU(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.NotNil(t, testACL.VerifyPeerCertificateServer(nil, fakeChains), "Rego policy rejects none OU")
 }
@@ -354,6 +361,7 @@ func TestVerifyOPARejectCommonName(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.NotNil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "Rego policy on different CN should be rejected")
 }
@@ -373,6 +381,7 @@ func TestVerifyOPAAcceptCommonName(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "Rego policy validates CN should pass")
 }
@@ -394,6 +403,7 @@ func TestVerifyOPAAcceptDNSn(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "Rego policy validates testing DNS names")
 }
@@ -417,6 +427,7 @@ func TestVerifyOPAAcceptURIs(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "Rego policy validates testing URIs")
 }
@@ -438,6 +449,7 @@ func TestVerifyOPAAcceptOneOU(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.Nil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "Rego policy validates one OU")
 }
@@ -459,6 +471,7 @@ func TestVerifyOPARejectAllOU(t *testing.T) {
 
 	testACL := ACL{
 		AllowOPAQuery: &allowQuery,
+		OPAQueryTimeout: 10*time.Second,
 	}
 	assert.NotNil(t, testACL.VerifyPeerCertificateClient(nil, fakeChains), "Rego policy rejects none OU")
 }

--- a/main.go
+++ b/main.go
@@ -81,11 +81,11 @@ var (
 	serverAllowedDNSs         = serverCommand.Flag("allow-dns", "Allow clients with given DNS subject alternative name (can be repeated).").PlaceHolder("DNS").Strings()
 	serverAllowedIPs          = serverCommand.Flag("allow-ip", "").Hidden().PlaceHolder("SAN").IPList()
 	serverAllowedURIs         = serverCommand.Flag("allow-uri", "Allow clients with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
-	serverAllowPolicy         = serverCommand.Flag("allow-policy", "Allow passing the location of an OPA rego file").String()
-	serverAllowQuery          = serverCommand.Flag("allow-query", "Allow defining a query to validate against the client certificate and the rego policy.").String()
+	serverAllowPolicy         = serverCommand.Flag("allow-policy", "Allow passing the location of an OPA rego file").PlaceHolder("POLICY").String()
+	serverAllowQuery          = serverCommand.Flag("allow-query", "Allow defining a query to validate against the client certificate and the rego policy.").PlaceHolder("QUERY").String()
 	serverDisableAuth         = serverCommand.Flag("disable-authentication", "Disable client authentication, no client certificate will be required.").Default("false").Bool()
-	serverAutoACMEFQDN        = serverCommand.Flag("auto-acme-cert", "Automatically obtain a certificate via ACME for the specified FQDN").PlaceHolder("www.example.com").String()
-	serverAutoACMEEmail       = serverCommand.Flag("auto-acme-email", "Email address associated with all ACME requests").PlaceHolder("admin@#example.com").String()
+	serverAutoACMEFQDN        = serverCommand.Flag("auto-acme-cert", "Automatically obtain a certificate via ACME for the specified FQDN").PlaceHolder("FQDN").String()
+	serverAutoACMEEmail       = serverCommand.Flag("auto-acme-email", "Email address associated with all ACME requests").PlaceHolder("EMAIL").String()
 	serverAutoACMEAgreedTOS   = serverCommand.Flag("auto-acme-agree-to-tos", "Agree to the Terms of Service of the ACME CA").Default("false").Bool()
 	serverAutoACMEProdCA      = serverCommand.Flag("auto-acme-ca", "Specify the URL to the ACME CA. Defaults to Let's Encrypt if not specified.").PlaceHolder("https://some-acme-ca.example.com/").String()
 	serverAutoACMETestCA      = serverCommand.Flag("auto-acme-testca", "Specify the URL to the ACME CA's Test/Staging environemnt. If set, all requests will go to this CA and --auto-acme-ca will be ignored.").PlaceHolder("https://testing.some-acme-ca.example.com/").String()
@@ -102,8 +102,8 @@ var (
 	clientAllowedDNSs    = clientCommand.Flag("verify-dns", "Allow servers with given DNS subject alternative name (can be repeated).").PlaceHolder("DNS").Strings()
 	clientAllowedIPs     = clientCommand.Flag("verify-ip", "").Hidden().PlaceHolder("SAN").IPList()
 	clientAllowedURIs    = clientCommand.Flag("verify-uri", "Allow servers with given URI subject alternative name (can be repeated).").PlaceHolder("URI").Strings()
-	clientAllowPolicy    = clientCommand.Flag("verify-policy", "Allow passing the location of an OPA rego file").String()
-	clientAllowQuery     = clientCommand.Flag("verify-query", "Allow defining a query to validate against the client certificate and the rego policy.").String()
+	clientAllowPolicy    = clientCommand.Flag("verify-policy", "Allow passing the location of an OPA rego file").PlaceHolder("POLICY").String()
+	clientAllowQuery     = clientCommand.Flag("verify-query", "Allow defining a query to validate against the client certificate and the rego policy.").PlaceHolder("QUERY").String()
 	clientDisableAuth    = clientCommand.Flag("disable-authentication", "Disable client authentication, no certificate will be provided to the server.").Default("false").Bool()
 
 	// TLS options
@@ -568,14 +568,14 @@ func serverListen(context *Context) error {
 	}
 
 	serverACL := auth.ACL{
-		AllowAll:      *serverAllowAll,
-		AllowedCNs:    *serverAllowedCNs,
-		AllowedOUs:    *serverAllowedOUs,
-		AllowedDNSs:   *serverAllowedDNSs,
-		AllowedIPs:    *serverAllowedIPs,
-		AllowOPAQuery: allowQuery,
-		AllowedURIs:   allowedURIs,
-		Logger:        logger,
+		AllowAll:        *serverAllowAll,
+		AllowedCNs:      *serverAllowedCNs,
+		AllowedOUs:      *serverAllowedOUs,
+		AllowedDNSs:     *serverAllowedDNSs,
+		AllowedIPs:      *serverAllowedIPs,
+		AllowOPAQuery:   allowQuery,
+		AllowedURIs:     allowedURIs,
+		OPAQueryTimeout: *timeoutDuration,
 	}
 
 	if *serverDisableAuth {
@@ -777,13 +777,13 @@ func clientBackendDialer(tlsConfigSource certloader.TLSConfigSource, network, ad
 	}
 
 	clientACL := auth.ACL{
-		AllowedCNs:    *clientAllowedCNs,
-		AllowedOUs:    *clientAllowedOUs,
-		AllowedDNSs:   *clientAllowedDNSs,
-		AllowedIPs:    *clientAllowedIPs,
-		AllowedURIs:   allowedURIs,
-		AllowOPAQuery: allowQuery,
-		Logger:        logger,
+		AllowedCNs:      *clientAllowedCNs,
+		AllowedOUs:      *clientAllowedOUs,
+		AllowedDNSs:     *clientAllowedDNSs,
+		AllowedIPs:      *clientAllowedIPs,
+		AllowedURIs:     allowedURIs,
+		AllowOPAQuery:   allowQuery,
+		OPAQueryTimeout: *timeoutDuration,
 	}
 
 	config.VerifyPeerCertificate = clientACL.VerifyPeerCertificateClient


### PR DESCRIPTION
This hooks up the connect timeout flag to the OPA query timeout, cleans up the flag placeholders a bit to make help output more readable, and updates the README and ACCESS-FLAGS docs.