### PR TITLE
Add macOS ARM build.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         version: [1.19.x]
         target: 
           - { os: 'darwin', platform: 'macos-latest', arch: 'amd64' }
+          - { os: 'darwin', platform: 'macos-latest', arch: 'arm64' }
           - { os: 'linux', platform: 'ubuntu-latest', arch: 'amd64' }
     runs-on: ${{ matrix.target.platform }}
     steps:


### PR DESCRIPTION
Please find a simple change to add an ARM build for Apple Silicon.

This is my first foray into trying to test GitHub Actions locally, and no surprise, it doesn't work there. The problem is that there's no macos-latest container to run with.

FWIW, I can quite easily just `CGO_ENABLED=1 GOARCH=arm64 make ghostunnel` on my M1 Mac.

I also toyed with changing the workflow and Makefile to additionally build a universal mac binary, but since I'm not seeing any codesigning, I have to imagine that if someone really wanted that they could download the two Darwin builds and `lipo -create -output ghostunnel ghostunnel-darwin-amd64 ghostunnel-darwin-arm64`.

So... ultimately this is a silly one-line PR masquerading as a feature request asking for a macOS Darwin build.