### PR TITLE
Avoid setting GetCertificate for SPIFFE in client mode if auth is disabled

### DIFF
--- a/certloader/spiffe_tls_config.go
+++ b/certloader/spiffe_tls_config.go
@@ -26,11 +26,12 @@ import (
 )
 
 type spiffeTLSConfigSource struct {
-	client *spiffeApi.Client
-	logger *log.Logger
+	client            *spiffeApi.Client
+	clientDisableAuth bool
+	logger            *log.Logger
 }
 
-func TLSConfigSourceFromWorkloadAPI(addr string, logger *log.Logger) (TLSConfigSource, error) {
+func TLSConfigSourceFromWorkloadAPI(addr string, clientDisableAuth bool, logger *log.Logger) (TLSConfigSource, error) {
 	client, err := spiffeApi.New(
 		context.Background(),
 		spiffeApi.WithAddr(addr),
@@ -40,8 +41,9 @@ func TLSConfigSourceFromWorkloadAPI(addr string, logger *log.Logger) (TLSConfigS
 		return nil, err
 	}
 	return &spiffeTLSConfigSource{
-		client: client,
-		logger: logger,
+		client:            client,
+		clientDisableAuth: clientDisableAuth,
+		logger:            logger,
 	}, nil
 }
 
@@ -73,14 +75,16 @@ func (s *spiffeTLSConfigSource) newConfig(base *tls.Config) (*spiffeTLSConfig, e
 	}
 
 	return &spiffeTLSConfig{
-		base:   base,
-		source: source,
+		base:              base,
+		source:            source,
+		clientDisableAuth: s.clientDisableAuth,
 	}, nil
 }
 
 type spiffeTLSConfig struct {
-	base   *tls.Config
-	source *spiffeApi.X509Source
+	base              *tls.Config
+	source            *spiffeApi.X509Source
+	clientDisableAuth bool
 }
 
 func (c *spiffeTLSConfig) GetClientConfig() *tls.Config {
@@ -94,7 +98,13 @@ func (c *spiffeTLSConfig) GetClientConfig() *tls.Config {
 	// authentication against the raw certificates.
 	config.InsecureSkipVerify = true
 	config.VerifyPeerCertificate = spiffeConfig.WrapVerifyPeerCertificate(config.VerifyPeerCertificate, c.source, spiffeConfig.AuthorizeAny())
-	config.GetClientCertificate = spiffeConfig.GetClientCertificate(c.source)
+	if !c.clientDisableAuth {
+		// If auth is disabled on the client side we need to not set
+		// the GetCertificate callback, because if we do it'll cause
+		// the client to block forever if the SPIFFE Workload API
+		// doesn't have a client certificate available for us.
+		config.GetClientCertificate = spiffeConfig.GetClientCertificate(c.source)
+	}
 	return config
 }
 

--- a/certloader/spiffe_tls_config.go
+++ b/certloader/spiffe_tls_config.go
@@ -110,7 +110,12 @@ func (c *spiffeTLSConfig) GetClientConfig() *tls.Config {
 
 func (c *spiffeTLSConfig) GetServerConfig() *tls.Config {
 	config := c.base.Clone()
-	config.ClientAuth = tls.RequireAnyClientCert
+
+	// Only set client requirement if not disabled in base.
+	if config.ClientAuth == tls.RequireAndVerifyClientCert {
+		config.ClientAuth = tls.RequireAnyClientCert
+	}
+
 	// Go TLS stack will do hostname validation with is not a part of SPIFFE
 	// authentication. Unfortunately there is no way to just skip hostname
 	// validation without having to turn off all verification. This is still

--- a/certloader/spiffe_tls_config_test.go
+++ b/certloader/spiffe_tls_config_test.go
@@ -41,7 +41,7 @@ func TestWorkloadAPIClientDisableAuth(t *testing.T) {
 
 	log := log.Default()
 
-	source, err := TLSConfigSourceFromWorkloadAPI(workloadAPI.Addr(), false, log)
+	source, err := TLSConfigSourceFromWorkloadAPI(workloadAPI.Addr(), true, log)
 	require.NoError(t, err)
 	defer source.(*spiffeTLSConfigSource).Close()
 
@@ -52,7 +52,7 @@ func TestWorkloadAPIClientDisableAuth(t *testing.T) {
 	clientConfig, err := source.GetClientConfig(clientBase)
 	require.NoError(t, err)
 	tlsConfig := clientConfig.GetClientConfig()
-	require.Nil(t, tlsConfig.GetCertificate)
+	require.Nil(t, tlsConfig.GetClientCertificate)
 }
 
 func TestWorkloadAPITLSConfigSource(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -836,7 +836,7 @@ func proxyLoggerFlags(flags []string) int {
 func getTLSConfigSource() (certloader.TLSConfigSource, error) {
 	if *useWorkloadAPI {
 		logger.Printf("using SPIFFE Workload API as certificate source")
-		source, err := certloader.TLSConfigSourceFromWorkloadAPI(*useWorkloadAPIAddr, logger)
+		source, err := certloader.TLSConfigSourceFromWorkloadAPI(*useWorkloadAPIAddr, *clientDisableAuth, logger)
 		if err != nil {
 			logger.Printf("error: unable to create workload API TLS source: %s\n", err)
 			return nil, err

--- a/main.go
+++ b/main.go
@@ -351,13 +351,11 @@ func clientValidateFlags() error {
 		(*certPath != "" && *keyPath != ""),
 		// A certificate, with the key in a PKCS#11 module
 		(*certPath != "" && hasPKCS11()),
-		// SPIFFE Workload API
-		*useWorkloadAPI,
 		// No credentials needed if auth is disabled
 		*clientDisableAuth,
 	})
 
-	if hasValidCredentials == 0 {
+	if hasValidCredentials == 0 && !*useWorkloadAPI {
 		return errors.New("at least one of --keystore, --cert/--key, --keychain-identity/issuer (if supported) or --disable-authentication flags is required")
 	}
 	if hasValidCredentials > 1 {
@@ -577,7 +575,7 @@ func serverListen(context *Context) error {
 	}
 
 	if *serverDisableAuth {
-		config.ClientAuth = tls.NoClientCert
+		config.ClientAuth = tls.RequestClientCert
 	} else {
 		config.VerifyPeerCertificate = serverACL.VerifyPeerCertificateServer
 	}


### PR DESCRIPTION
Avoid setting GetCertificate for SPIFFE in client mode if auth is disabled