### PR TITLE
Support disable-authentication on client and server with SPIFFE

### DIFF
--- a/certloader/spiffe_tls_config.go
+++ b/certloader/spiffe_tls_config.go
@@ -110,7 +110,12 @@ func (c *spiffeTLSConfig) GetClientConfig() *tls.Config {
 
 func (c *spiffeTLSConfig) GetServerConfig() *tls.Config {
 	config := c.base.Clone()
-	config.ClientAuth = tls.RequireAnyClientCert
+
+	// Only set client requirement if not disabled in base.
+	if config.ClientAuth == tls.RequireAndVerifyClientCert {
+		config.ClientAuth = tls.RequireAnyClientCert
+	}
+
 	// Go TLS stack will do hostname validation with is not a part of SPIFFE
 	// authentication. Unfortunately there is no way to just skip hostname
 	// validation without having to turn off all verification. This is still

--- a/main.go
+++ b/main.go
@@ -351,13 +351,11 @@ func clientValidateFlags() error {
 		(*certPath != "" && *keyPath != ""),
 		// A certificate, with the key in a PKCS#11 module
 		(*certPath != "" && hasPKCS11()),
-		// SPIFFE Workload API
-		*useWorkloadAPI,
 		// No credentials needed if auth is disabled
 		*clientDisableAuth,
 	})
 
-	if hasValidCredentials == 0 {
+	if hasValidCredentials == 0 && !*useWorkloadAPI {
 		return errors.New("at least one of --keystore, --cert/--key, --keychain-identity/issuer (if supported) or --disable-authentication flags is required")
 	}
 	if hasValidCredentials > 1 {
@@ -577,7 +575,7 @@ func serverListen(context *Context) error {
 	}
 
 	if *serverDisableAuth {
-		config.ClientAuth = tls.NoClientCert
+		config.ClientAuth = tls.RequestClientCert
 	} else {
 		config.VerifyPeerCertificate = serverACL.VerifyPeerCertificateServer
 	}


### PR DESCRIPTION
Fixes #390 

In #390, you still had `config.ClientAuth = tls.RequireAnyClientCert` for `GetServerConfig` in place. This overrides the `NoClientCert` from `main.go`.

`--disable-authentication` on the `server` is currently fully disabling client authentication by applying `config.ClientAuth = tls.NoClientCert`. Using `tls.RequestClientCert` would at least allow to show the certificate (if optionally provided).

The client still didn't allow to enable `--disable-authentication`, since the `hasValidCredentials` was containing it. I therefore refactored the check.

It now fully works with SPIFFE as expected. You might want to test again if all other use-cases work as well with `config.ClientAuth = tls.RequestClientCert`. The tests all passed.