### PR TITLE
test: use netcat-traditional in integration test Docker image

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -12,7 +12,7 @@ FROM golang:${GO_VERSION}
 
 # Install build dependencies
 RUN apt-get update && \
-    apt-get install -y build-essential python3-minimal netcat softhsm2 rsyslog git python3-distutils </dev/null && \
+    apt-get install -y build-essential python3-minimal netcat-traditional softhsm2 rsyslog git python3-distutils </dev/null && \
     mkdir -p /etc/softhsm /var/lib/softhsm/tokens /go/src/github.com/ghostunnel/ghostunnel && \
     go install github.com/wadey/gocovmerge@latest && \
     go install golang.org/x/tools/cmd/cover@latest


### PR DESCRIPTION
Fixes the linux integration tests CI job.

Here's an example of the failing test: https://github.com/ghostunnel/ghostunnel/actions/runs/5469132117/jobs/9957675360#step:3:57

```
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47

E: Package 'netcat' has no installation candidate
```

At some point, the netcat package must have been remove/renamed. 

Let me know if you'd prefer `netcat-openbsd` or `netcat-traditional`!