### PR TITLE
Fix nil ptr deref on Windows/Linux when keychain flags are used

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,10 @@ func init() {
 		keychainIssuer = app.Flag("keychain-issuer", "Use local keychain identity with given issuer name (instead of keystore file).").PlaceHolder("CN").String()
 		if runtime.GOOS == "darwin" {
 			keychainRequireToken = app.Flag("keychain-require-token", "Require keychain identity to be from a physical token (sets 'access group' to 'token').").Bool()
+		} else {
+			// The "require token" flag doesn't do anything on Windows/Linux, so we hide it.
+			isFalse := false
+			keychainRequireToken = &isFalse
 		}
 	}
 


### PR DESCRIPTION
Fix nil ptr deref on Windows/Linux when keychain flags are used.

The panic comes from line 67 in `tls.go`:
```
	if hasKeychainIdentity() {
		logger.Printf("using operating system keychain as certificate source")
		return certloader.CertificateFromKeychainIdentity(*keychainIdentity, *keychainIssuer, caBundlePath, *keychainRequireToken)
	}
```

Flag `keychainRequireToken` can't be nil, even if it's not supported on Windows/Linux.