### PR TITLE
Skip Codecov upload on Dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         run: GO_VERSION=${{ matrix.version }} make docker-test
       - name: Codecov upload
         uses: codecov/codecov-action@v4
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           files: ./coverage/all.profile
           flags: linux
@@ -76,6 +77,7 @@ jobs:
         run: make test
       - name: Codecov upload
         uses: codecov/codecov-action@v4
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           files: ./coverage/all.profile
           flags: darwin


### PR DESCRIPTION
Skip Codecov upload on Dependabot PRs. Dependabot doesn't have access to the token required for upload, so it fails every time. But we don't need coverage information when updating dependencies anyway so let's skip it. 