### PR TITLE
Windows implementation supports RSA-PSS

### DIFF
--- a/certstore/certstore_windows.go
+++ b/certstore/certstore_windows.go
@@ -358,11 +358,6 @@ func (wpk *winPrivateKey) Public() crypto.PublicKey {
 
 // Sign implements the crypto.Signer interface.
 func (wpk *winPrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	if _, isPSS := opts.(*rsa.PSSOptions); isPSS {
-		// Windows implementation does not currently support RSA-PSS.
-		return nil, ErrUnsupportedHash
-	}
-
 	if wpk.capiProv != 0 {
 		return wpk.capiSignHash(opts, digest)
 	} else if wpk.cngHandle != 0 {


### PR DESCRIPTION
Support for RSA-PSS on Windows was merged in 23108a63, but this line of code was never updated.