### PR TITLE
Add optional /_shutdown endpoint for terminating via HTTP POST

### DIFF
--- a/tests/test-client-shutdown-sigterm.py
+++ b/tests/test-client-shutdown-sigterm.py
@@ -28,13 +28,14 @@ if __name__ == "__main__":
         pair1 = SocketPair(
             TcpClient(13001), TlsServer('server', 'root', 13002))
         pair1.validate_can_send_from_client("toto", "pair1 works")
+        pair1.cleanup()
 
-        # shut down ghostunnel with connection open, make sure it doesn't hang
         print_ok('attempting to terminate ghostunnel via SIGTERM signals')
+        ghostunnel.terminate()
+
         for n in range(0, 90):
             try:
                 try:
-                    ghostunnel.terminate()
                     ghostunnel.wait(timeout=1)
                 except BaseException:
                     pass

--- a/tests/test-server-shutdown-http.py
+++ b/tests/test-server-shutdown-http.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
-from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpClient, TlsClient, TlsServer, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpServer, TlsClient, print_ok, run_ghostunnel, terminate
+import urllib.request
+import urllib.error
+import urllib.parse
 import time
 import os
 
@@ -13,26 +16,30 @@ if __name__ == "__main__":
         root.create_signed_cert('client')
 
         # start ghostunnel
-        ghostunnel = run_ghostunnel(['client',
+        ghostunnel = run_ghostunnel(['server',
                                      '--listen={0}:13001'.format(LOCALHOST),
                                      '--target={0}:13002'.format(LOCALHOST),
-                                     '--keystore=client.p12',
+                                     '--keystore=server.p12',
                                      '--cacert=root.crt',
-                                     '--shutdown-timeout=1s',
+                                     '--allow-ou=client',
+                                     '--enable-shutdown',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT)])
 
+        def urlopen(path):
+            return urllib.request.urlopen(path, cafile='root.crt')
+
         # wait for startup
-        TlsClient(None, 'root', STATUS_PORT).connect(20, 'client')
+        TlsClient(None, 'root', STATUS_PORT).connect(20, 'server')
 
         # create connections with client
         pair1 = SocketPair(
-            TcpClient(13001), TlsServer('server', 'root', 13002))
+            TlsClient('client', 'root', 13001), TcpServer(13002))
         pair1.validate_can_send_from_client("toto", "pair1 works")
+        pair1.cleanup()
 
-        # shut down ghostunnel with connection open, make sure it doesn't hang
-        print_ok('attempting to terminate ghostunnel via SIGTERM signals')
-        ghostunnel.terminate()
+        print_ok('attempting to terminate ghostunnel via HTTP POST')
+        urlopen(urllib.request.Request("https://{0}:{1}/_shutdown".format(LOCALHOST, STATUS_PORT), method='POST'))
 
         for n in range(0, 90):
             try:
@@ -49,11 +56,6 @@ if __name__ == "__main__":
 
         if not stopped:
             raise Exception('ghostunnel did not terminate within 90 seconds')
-
-        # We expect retv != 0 because of timeout
-        if ghostunnel.returncode == 0:
-            raise Exception(
-                'ghostunnel terminated gracefully instead of timing out?')
 
         print_ok("OK (terminated)")
     finally:

--- a/tests/test-server-shutdown-sigterm.py
+++ b/tests/test-server-shutdown-sigterm.py
@@ -29,13 +29,14 @@ if __name__ == "__main__":
         pair1 = SocketPair(
             TlsClient('client', 'root', 13001), TcpServer(13002))
         pair1.validate_can_send_from_client("toto", "pair1 works")
+        pair1.cleanup()
 
-        # shut down ghostunnel with connection open, make sure it doesn't hang
         print_ok('attempting to terminate ghostunnel via SIGTERM signals')
+        ghostunnel.terminate()
+
         for n in range(0, 90):
             try:
                 try:
-                    ghostunnel.terminate()
                     ghostunnel.wait(timeout=1)
                 except BaseException:
                     pass

--- a/tests/test-server-shutdown-timeout.py
+++ b/tests/test-server-shutdown-timeout.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
         # shut down ghostunnel with connection open, make sure it doesn't hang
         print_ok('attempting to terminate ghostunnel via SIGTERM signals')
         ghostunnel.terminate()
+
         for n in range(0, 90):
             try:
                 try:


### PR DESCRIPTION
When running as a sidecar container in Kubernetes to jobs, the primary container needs a way to signal to the other containers they should also terminate. Although you can share the process namespace, this is simpler to achieve since you don't have to look for the correct PID.

I also tweaked the sigterm tests to only TERM once and without an open connection since while working on the HTTP tests (which were modeled after those) the server was reaching the timeout because of the open connection which is already covered in the timeout tests.