### PR TITLE
Fix Windows unit test error relating to RSA-PSS on CAPI keys

### DIFF
--- a/certstore/certstore_windows.go
+++ b/certstore/certstore_windows.go
@@ -461,6 +461,11 @@ func (wpk *winPrivateKey) capiSignHash(opts crypto.SignerOpts, digest []byte) ([
 	if len(digest) != hash.Size() {
 		return nil, errors.New("bad digest for hash")
 	}
+	if _, isPSS := opts.(*rsa.PSSOptions); isPSS {
+		// RSA-PSS is implemented only via CNG, not via CAPI.
+		// CNG has been available since Windows Vista / Server 2016.
+		return nil, ErrUnsupportedHash
+	}
 
 	// Figure out which CryptoAPI hash algorithm we're using.
 	var hash_alg C.ALG_ID

--- a/certstore/certstore_windows.go
+++ b/certstore/certstore_windows.go
@@ -403,7 +403,7 @@ func (wpk *winPrivateKey) cngSignHash(opts crypto.SignerOpts, digest []byte) ([]
 
 		if pssOpts, ok := opts.(*rsa.PSSOptions); ok {
 			saltLen := pssOpts.SaltLength
-			if saltLen == rsa.PSSSaltLengthEqualsHash {
+			if saltLen == rsa.PSSSaltLengthAuto || saltLen == rsa.PSSSaltLengthEqualsHash {
 				saltLen = len(digest)
 			}
 			padPtr = unsafe.Pointer(&C.BCRYPT_PSS_PADDING_INFO{
@@ -463,7 +463,7 @@ func (wpk *winPrivateKey) capiSignHash(opts crypto.SignerOpts, digest []byte) ([
 	}
 	if _, isPSS := opts.(*rsa.PSSOptions); isPSS {
 		// RSA-PSS is implemented only via CNG, not via CAPI.
-		// CNG has been available since Windows Vista / Server 2016.
+		// CNG has been available since Windows Vista / Server 2008.
 		return nil, ErrUnsupportedHash
 	}
 


### PR DESCRIPTION
(1) The `certstore` module supports two backends on Windows, CAPI and CNG. Support for RSA-PSS on CNG was previously added in 23108a6373dbec25cce94a710abe88625b264c84, though was not functional until #459. However, the change in #459 removed the check for RSA-PSS for both the CAPI and CNG code paths, even though RSA-PSS was only supported in CNG. This change should fix the issue by returning an error if RSA-PSS is used on CAPI keys.  
(2) The CNG implementation for RSA-PSS did not check for `PSSSaltLengthAuto` on `rsa.PSSOptions`. This meant that `saltLen` passed to CNG was set to 0 when the caller specified auto. To fix this, we set the salt length to the digest length if auto is specified. 