### PR TITLE
Windows: Support LOCAL_MACHINE and CURRENT_SERVICE

### DIFF
--- a/certloader/certstore_disabled.go
+++ b/certloader/certstore_disabled.go
@@ -18,7 +18,10 @@
 
 package certloader
 
-import "errors"
+import (
+	"errors"
+	"log"
+)
 
 // SupportsKeychain returns true or false, depending on whether the
 // binary was built with Certstore/Keychain support or not (requires CGO, recent
@@ -29,7 +32,7 @@ func SupportsKeychain() bool {
 
 // CertificateFromKeychainIdentity creates a reloadable certificate from a system keychain identity.
 func CertificateFromKeychainIdentity(
-	commonNameOrSerial string, issuerName string, caBundlePath string, requireToken bool,
+	commonNameOrSerial string, issuerName string, caBundlePath string, requireToken bool, logger *log.Logger,
 ) (Certificate, error) {
 	return nil, errors.New("not supported")
 }

--- a/certloader/certstore_test.go
+++ b/certloader/certstore_test.go
@@ -17,12 +17,18 @@
 package certloader
 
 import (
+	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInvalidKeychainIdentity(t *testing.T) {
-	_, err := CertificateFromKeychainIdentity("", "", "", false)
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	ident, err := CertificateFromKeychainIdentity("!", "!", "!", false, logger)
+	if ident != nil {
+		t.Logf("loaded invalid identity: %v", ident)
+	}
 	assert.NotNil(t, err, "should not load invalid identity")
 }

--- a/certloader/pkcs11_test.go
+++ b/certloader/pkcs11_test.go
@@ -22,6 +22,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"log"
+	"os"
 	"testing"
 	"unsafe"
 
@@ -29,7 +31,8 @@ import (
 )
 
 func TestInvalidPKCS11Module(t *testing.T) {
-	_, err := CertificateFromPKCS11Module("", "", "", "", "")
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	_, err := CertificateFromPKCS11Module("", "", "", "", "", logger)
 	assert.NotNil(t, err, "should not load invalid PKCS11 certificate/key")
 }
 

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"errors"
+	"log"
 )
 
 var (
@@ -18,8 +19,8 @@ const (
 )
 
 // Open opens the system's certificate store.
-func Open() (Store, error) {
-	return openStore()
+func Open(logger *log.Logger) (Store, error) {
+	return openStore(logger)
 }
 
 // Store represents the system's certificate store.

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"unsafe"
 )
 
@@ -37,7 +38,7 @@ var (
 type macStore int
 
 // openStore is a function for opening a macStore.
-func openStore() (macStore, error) {
+func openStore(logger *log.Logger) (Store, error) {
 	return macStore(0), nil
 }
 

--- a/certstore/certstore_linux.go
+++ b/certstore/certstore_linux.go
@@ -1,8 +1,11 @@
 package certstore
 
-import "errors"
+import (
+	"errors"
+	"log"
+)
 
 // Implement this function, just to silence other compiler errors.
-func openStore() (Store, error) {
+func openStore(logger *log.Logger) (Store, error) {
 	return nil, errors.New("certstore only works on macOS and Windows")
 }

--- a/certstore/certstore_windows.go
+++ b/certstore/certstore_windows.go
@@ -38,6 +38,7 @@ import (
 	"encoding/asn1"
 	"fmt"
 	"io"
+	"log"
 	"math/big"
 	"unicode/utf16"
 	"unsafe"
@@ -72,24 +73,70 @@ var winAPIFlag C.DWORD = C.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG
 
 // winStore is a wrapper around a C.HCERTSTORE.
 type winStore struct {
-	store C.HCERTSTORE
+	userStore   C.HCERTSTORE
+	extraStores []C.HCERTSTORE
+	logger      *log.Logger
 }
 
 // openStore opens the current user's personal cert store.
-func openStore() (*winStore, error) {
+func openStore(logger *log.Logger) (*winStore, error) {
 	storeName := unsafe.Pointer(stringToUTF16("MY"))
 	defer C.free(storeName)
 
-	store := C.CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0, C.CERT_SYSTEM_STORE_CURRENT_USER, storeName)
-	if store == nil {
+	userStore := C.CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0, C.CERT_SYSTEM_STORE_CURRENT_USER, storeName)
+	if userStore == nil {
+		logger.Printf("certstore: failed to open key store 'CURRENT_USER', aborting")
 		return nil, lastError("failed to open system cert store")
 	}
 
-	return &winStore{store}, nil
+	ret := &winStore{
+		userStore:   userStore,
+		extraStores: []C.HCERTSTORE{},
+		logger:      logger,
+	}
+
+	// Additional stores to use to look for certificates in Identities().
+	// The identity we want to load might be in the "current service" or "local
+	// machine" stores, so we need to open those to check.
+	extraStores := map[string]C.DWORD{
+		"CURRENT_SERVICE": C.CERT_SYSTEM_STORE_CURRENT_SERVICE,
+		"LOCAL_MACHINE":   C.CERT_SYSTEM_STORE_LOCAL_MACHINE,
+	}
+	for friendlyName, storeIdent := range extraStores {
+		store := C.CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0, storeIdent, storeName)
+		if store == nil {
+			logger.Printf("certstore: failed to open key store '%s', skipping", friendlyName)
+			continue
+		}
+
+		ret.extraStores = append(ret.extraStores, store)
+	}
+
+	return ret, nil
 }
 
 // Identities implements the Store interface.
 func (s *winStore) Identities(unusedFlags int) ([]Identity, error) {
+	identities := []Identity{}
+	userIdentities, err := identitiesForStore(s.userStore)
+	if err != nil {
+		s.logger.Printf("certstore: failed to get identities from user store: %v", err)
+	} else {
+		identities = append(identities, userIdentities...)
+	}
+
+	for _, extraStore := range s.extraStores {
+		extraIdentities, err := identitiesForStore(extraStore)
+		if err != nil {
+			s.logger.Printf("certstore: failed to get identities from extra store: %v", err)
+			continue
+		}
+		identities = append(identities, extraIdentities...)
+	}
+	return identities, nil
+}
+
+func identitiesForStore(store C.HCERTSTORE) ([]Identity, error) {
 	var (
 		err    error
 		idents = []Identity{}
@@ -104,7 +151,7 @@ func (s *winStore) Identities(unusedFlags int) ([]Identity, error) {
 	)
 
 	for {
-		if chainCtx = C.CertFindChainInStore(s.store, encoding, flags, findType, paramsPtr, chainCtx); chainCtx == nil {
+		if chainCtx = C.CertFindChainInStore(store, encoding, flags, findType, paramsPtr, chainCtx); chainCtx == nil {
 			break
 		}
 		if chainCtx.cChain < 1 {
@@ -192,7 +239,7 @@ func (s *winStore) Import(data []byte, password string) error {
 		}
 
 		// Copy the cert to the system store.
-		if ok := C.CertAddCertificateContextToStore(s.store, ctx, C.CERT_STORE_ADD_REPLACE_EXISTING, nil); ok == winFalse {
+		if ok := C.CertAddCertificateContextToStore(s.userStore, ctx, C.CERT_STORE_ADD_REPLACE_EXISTING, nil); ok == winFalse {
 			return lastError("failed to add importerd certificate to MY store")
 		}
 	}
@@ -202,8 +249,13 @@ func (s *winStore) Import(data []byte, password string) error {
 
 // Close implements the Store interface.
 func (s *winStore) Close() {
-	C.CertCloseStore(s.store, 0)
-	s.store = nil
+	C.CertCloseStore(s.userStore, 0)
+	for _, extraStore := range s.extraStores {
+		C.CertCloseStore(extraStore, 0)
+	}
+
+	s.userStore = nil
+	s.extraStores = nil
 }
 
 // winIdentity implements the Identity interface.

--- a/certstore/main_test.go
+++ b/certstore/main_test.go
@@ -10,6 +10,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/github/smimesign/fakeca"
@@ -45,7 +47,8 @@ func init() {
 }
 
 func withStore(t *testing.T, cb func(Store)) {
-	store, err := Open()
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	store, err := Open(logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +103,8 @@ func withIdentity(t *testing.T, i *fakeca.Identity, cb func(Identity)) {
 }
 
 func clearFixtures() {
-	store, err := Open()
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	store, err := Open(logger)
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -909,7 +909,7 @@ func getTLSConfigSource(disableAuth bool) (certloader.TLSConfigSource, error) {
 		return source, nil
 	}
 
-	cert, err := buildCertificate(*keystorePath, *certPath, *keyPath, *keystorePass, *caBundlePath)
+	cert, err := buildCertificate(*keystorePath, *certPath, *keyPath, *keystorePass, *caBundlePath, logger)
 	if err != nil {
 		logger.Printf("error: unable to load certificates: %s\n", err)
 		return nil, err

--- a/tls.go
+++ b/tls.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/ghostunnel/ghostunnel/certloader"
@@ -53,18 +54,18 @@ var cipherSuites = map[string][]uint16{
 }
 
 // Build reloadable certificate
-func buildCertificate(keystorePath, certPath, keyPath, keystorePass, caBundlePath string) (certloader.Certificate, error) {
+func buildCertificate(keystorePath, certPath, keyPath, keystorePass, caBundlePath string, logger *log.Logger) (certloader.Certificate, error) {
 	if hasPKCS11() {
 		logger.Printf("using PKCS#11 module as certificate source")
 		if keystorePath != "" {
-			return buildCertificateFromPKCS11(keystorePath, caBundlePath)
+			return buildCertificateFromPKCS11(keystorePath, caBundlePath, logger)
 		} else {
-			return buildCertificateFromPKCS11(certPath, caBundlePath)
+			return buildCertificateFromPKCS11(certPath, caBundlePath, logger)
 		}
 	}
 	if hasKeychainIdentity() {
 		logger.Printf("using operating system keychain as certificate source")
-		return certloader.CertificateFromKeychainIdentity(*keychainIdentity, *keychainIssuer, caBundlePath, *keychainRequireToken)
+		return certloader.CertificateFromKeychainIdentity(*keychainIdentity, *keychainIssuer, caBundlePath, *keychainRequireToken, logger)
 	}
 	if keyPath != "" && certPath != "" {
 		logger.Printf("using cert/key files on disk as certificate source")
@@ -78,8 +79,8 @@ func buildCertificate(keystorePath, certPath, keyPath, keystorePass, caBundlePat
 	return certloader.NoCertificate(caBundlePath)
 }
 
-func buildCertificateFromPKCS11(certificatePath, caBundlePath string) (certloader.Certificate, error) {
-	return certloader.CertificateFromPKCS11Module(certificatePath, caBundlePath, *pkcs11Module, *pkcs11TokenLabel, *pkcs11PIN)
+func buildCertificateFromPKCS11(certificatePath, caBundlePath string, logger *log.Logger) (certloader.Certificate, error) {
+	return certloader.CertificateFromPKCS11Module(certificatePath, caBundlePath, *pkcs11Module, *pkcs11TokenLabel, *pkcs11PIN, logger)
 }
 
 func hasPKCS11() bool {

--- a/tls_test.go
+++ b/tls_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"encoding/base64"
+	"log"
 	"os"
 	"runtime"
 	"testing"
@@ -215,27 +216,28 @@ func TestBuildConfig(t *testing.T) {
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.MinVersion == tls.VersionTLS12, "must have correct TLS min version")
 
-	cert, err := buildCertificate("", "", "", "", tmpKeystoreSeparateCert.Name())
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	cert, err := buildCertificate("", "", "", "", tmpKeystoreSeparateCert.Name(), logger)
 	assert.NotNil(t, cert, "cert with empty keystorePath should not be nil")
 	assert.Nil(t, err, "empty keystorePath should not raise an error")
 
-	cert, err = buildCertificate(tmpKeystore.Name(), "", "", "totes invalid", tmpKeystoreSeparateCert.Name())
+	cert, err = buildCertificate(tmpKeystore.Name(), "", "", "totes invalid", tmpKeystoreSeparateCert.Name(), logger)
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid keystore pass")
 
-	cert, err = buildCertificate("does-not-exist", "", "", testKeystorePassword, tmpKeystoreSeparateCert.Name())
+	cert, err = buildCertificate("does-not-exist", "", "", testKeystorePassword, tmpKeystoreSeparateCert.Name(), logger)
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject missing keystore (not found)")
 
-	cert, err = buildCertificate(tmpKeystoreNoPrivKey.Name(), "", "", "", tmpKeystoreSeparateCert.Name())
+	cert, err = buildCertificate(tmpKeystoreNoPrivKey.Name(), "", "", "", tmpKeystoreSeparateCert.Name(), logger)
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid keystore (no private key)")
 
-	cert, err = buildCertificate("/dev/null", "", "", "", tmpKeystoreSeparateCert.Name())
+	cert, err = buildCertificate("/dev/null", "", "", "", tmpKeystoreSeparateCert.Name(), logger)
 	assert.Nil(t, cert, "cert with invalid params should be nil")
 	assert.NotNil(t, err, "should reject invalid keystore (empty)")
 
-	cert, err = buildCertificate("", tmpKeystoreSeparateCert.Name(), tmpKeystoreSeparateKey.Name(), "", tmpKeystoreSeparateCert.Name())
+	cert, err = buildCertificate("", tmpKeystoreSeparateCert.Name(), tmpKeystoreSeparateKey.Name(), "", tmpKeystoreSeparateCert.Name(), logger)
 	assert.NotNil(t, cert, "cert with separate key should not be nil")
 	assert.Nil(t, err, "cert with separate key should be ok")
 }
@@ -284,7 +286,8 @@ func TestReload(t *testing.T) {
 	defer os.Remove(tmpCaBundle.Name())
 	defer os.Remove(tmpKeystore.Name())
 
-	c, err := buildCertificate(tmpKeystore.Name(), "", "", testKeystorePassword, tmpCaBundle.Name())
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	c, err := buildCertificate(tmpKeystore.Name(), "", "", testKeystorePassword, tmpCaBundle.Name(), logger)
 	assert.Nil(t, err, "should be able to build certificate")
 
 	c.Reload()
@@ -305,7 +308,8 @@ func TestBuildConfigSystemRoots(t *testing.T) {
 
 	defer os.Remove(tmpKeystore.Name())
 
-	c, err := buildCertificate(tmpKeystore.Name(), "", "", testKeystorePassword, "")
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	c, err := buildCertificate(tmpKeystore.Name(), "", "", testKeystorePassword, "", logger)
 	assert.Nil(t, err, "should be able to build certificate")
 
 	c.Reload()


### PR DESCRIPTION
Add support for LOCAL_MACHINE and CURRENT_SERVICE keychains on Windows, because we might want to load our identities from there. We still prefer the CURRENT_USER keystore first and foremost. Also, this change adds additional logging for the certstore module.

Work in progress -- opening this up here so I can run Windows tests on Github.