### PR TITLE
Fetch tags when checking out code in Github Actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -24,8 +24,10 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Build binary
         run: |
           CGO_ENABLED=1 GOARCH=amd64 make ghostunnel
@@ -56,8 +58,10 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Build binary
         run: |
           CGO_ENABLED=1 GOARCH=amd64 make ghostunnel
@@ -94,8 +98,10 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Build binary
         run: make ghostunnel
       - name: Upload artifact

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Set up emulation
         uses: docker/setup-qemu-action@v3
       - name: Set up buildx command

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,8 @@ jobs:
         version: [1.23.x]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,10 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Build binary
         run: |
           CGO_ENABLED=1 GOARCH=amd64 make ghostunnel
@@ -54,8 +56,10 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Build binary
         run: |
           CGO_ENABLED=1 GOARCH=amd64 make ghostunnel
@@ -92,8 +96,10 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Build binary
         run: |
           make ghostunnel
@@ -111,7 +117,10 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -137,7 +146,10 @@ jobs:
         - { os: 'darwin', arch: 'arm64' }
         - { os: 'darwin', arch: 'universal' }
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -162,7 +174,10 @@ jobs:
         target:
         - { os: 'windows', arch: 'amd64' }
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        fetch-depth: 100
+        fetch-tags: true
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: ${{ matrix.version }}
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Build binary
         run: make ghostunnel
@@ -36,7 +36,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Run tests 
         run: GO_VERSION=${{ matrix.version }} make docker-test
@@ -71,7 +71,7 @@ jobs:
           python-version: '3.11.x'
       - name: Install gocovmerge
         run: go install github.com/wadey/gocovmerge@latest
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Run tests
         run: make test


### PR DESCRIPTION
Fetch tags when checking out code in Github Actions. This is necessary for "git describe" to work correctly on builds, so that "ghostunnel --version" can show the proper version and not just the revision. 