### PR TITLE
Fix integration tests for Python 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 .PHONY: clean
 
 # Run all tests (unit + integration tests)
-test: unit $(INTEGRATION_TESTS)
+test: unit integration
 	gocovmerge coverage/*.profile | grep -v "internal/test" > coverage/all.profile
 	@echo "PASS"
 .PHONY: test
@@ -34,6 +34,9 @@ unit:
 	@mkdir -p coverage
 	go test -v -covermode=count -coverprofile=coverage/unit-test.profile ./...
 .PHONY: unit
+
+integration: $(INTEGRATION_TESTS)
+.PHONY: integration
 
 # Run integration tests
 $(INTEGRATION_TESTS): ghostunnel.test

--- a/tests/test-client-shutdown-http.py
+++ b/tests/test-client-shutdown-http.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpClient, TlsClient, TlsServer, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpClient, TlsClient, TlsServer, print_ok, run_ghostunnel, terminate, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -24,9 +24,6 @@ if __name__ == "__main__":
                                      '--enable-shutdown',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT)])
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # wait for startup
         TlsClient(None, 'root', STATUS_PORT).connect(20, 'client')

--- a/tests/test-client-status-port.py
+++ b/tests/test-client-status-port.py
@@ -4,7 +4,7 @@
 Ensures that /_status endpoint works.
 """
 
-from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, print_ok, run_ghostunnel, terminate, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -30,9 +30,6 @@ if __name__ == "__main__":
                                      '--cacert=root.crt',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT)])
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # block until ghostunnel is up
         TcpClient(STATUS_PORT).connect(20)

--- a/tests/test-server-metrics-endpoint.py
+++ b/tests/test-server-metrics-endpoint.py
@@ -4,7 +4,7 @@
 Test that ensures that metrics endpoint works.
 """
 
-from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, print_ok, run_ghostunnel, terminate, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -28,9 +28,6 @@ if __name__ == "__main__":
                                      '--enable-pprof',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT)])
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # Wait until ghostunnel is up
         TcpClient(STATUS_PORT).connect(20)

--- a/tests/test-server-quiet-all-logs.py
+++ b/tests/test-server-quiet-all-logs.py
@@ -4,7 +4,7 @@
 Ensures that --quiet=all disables any and all logging. 
 """
 
-from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, TcpServer, print_ok, run_ghostunnel, terminate, SocketPair
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, TcpServer, print_ok, run_ghostunnel, terminate, SocketPair, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -34,9 +34,6 @@ if __name__ == '__main__':
                                                                STATUS_PORT)],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # block until ghostunnel is up
         TcpClient(STATUS_PORT).connect(20)

--- a/tests/test-server-quiet-conn-logs.py
+++ b/tests/test-server-quiet-conn-logs.py
@@ -4,7 +4,7 @@
 Ensures that --quiet=conns disables logging about new connections.
 """
 
-from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, TcpServer, print_ok, run_ghostunnel, terminate, SocketPair
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, TcpServer, print_ok, run_ghostunnel, terminate, SocketPair, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -34,9 +34,6 @@ if __name__ == '__main__':
                                                                STATUS_PORT)],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # block until ghostunnel is up
         TcpClient(STATUS_PORT).connect(20)

--- a/tests/test-server-shutdown-http.py
+++ b/tests/test-server-shutdown-http.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpServer, TlsClient, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpServer, TlsClient, print_ok, run_ghostunnel, terminate, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -25,9 +25,6 @@ if __name__ == "__main__":
                                      '--enable-shutdown',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT)])
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # wait for startup
         TlsClient(None, 'root', STATUS_PORT).connect(20, 'server')

--- a/tests/test-server-status-port.py
+++ b/tests/test-server-status-port.py
@@ -4,7 +4,7 @@
 Ensures that /_status endpoint works.
 """
 
-from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, TlsClient, print_ok, run_ghostunnel, terminate, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -32,9 +32,6 @@ if __name__ == "__main__":
                                      '--allow-ou=client',
                                      '--status={0}:{1}'.format(LOCALHOST,
                                                                STATUS_PORT)])
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # block until ghostunnel is up
         TcpClient(STATUS_PORT).connect(20)

--- a/tests/test-server-tls-handshake-timeout.py
+++ b/tests/test-server-tls-handshake-timeout.py
@@ -4,7 +4,7 @@
 Simulates a hanging handshake, waits for timeout.
 """
 
-from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, print_ok, run_ghostunnel, terminate
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, print_ok, run_ghostunnel, terminate, urlopen
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -35,9 +35,6 @@ if __name__ == "__main__":
         client = TcpClient(13000)
         client.connect(20)
         client.get_socket().setblocking(False)
-
-        def urlopen(path):
-            return urllib.request.urlopen(path, cafile='root.crt')
 
         # wait until handshake times out
         timeout = False


### PR DESCRIPTION
Fix integration tests for Python 3.12:
* ssl.wrap_socket is now part of ssl.SSLContext
* Python is now pickier about extensions on root certs
* urlopen needs a context to set CA certs