### PR TITLE
Improve proxy performance and connection handling

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -146,10 +146,10 @@ func TestFlagValidation(t *testing.T) {
 	assert.NotNil(t, err, "--target-status should start with http:// or https://")
 	*serverStatusTargetAddress = ""
 
-	*timeoutDuration = 0
+	*connectTimeout = 0
 	err = validateFlags(nil)
 	assert.NotNil(t, err, "invalid --connect-timeout should be rejected")
-	*timeoutDuration = 10 * time.Second
+	*connectTimeout = 10 * time.Second
 
 	isTrue := true
 	somePath := "/tmp/test"

--- a/proxy/benchmark_test.go
+++ b/proxy/benchmark_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func BenchmarkCopyData(b *testing.B) {
-	proxy := New(nil, 60*time.Second, nil, &testLogger{}, LogEverything, false)
+	proxy := New(nil, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
 
 	for i := 0; i < 16; i++ {
 		b.Run(fmt.Sprintf("%d bytes", 1<<i), func(b *testing.B) {

--- a/proxy/benchmark_test.go
+++ b/proxy/benchmark_test.go
@@ -1,0 +1,58 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func BenchmarkCopyData(b *testing.B) {
+	proxy := New(nil, 60*time.Second, nil, &testLogger{}, LogEverything, false)
+
+	for i := 0; i < 16; i++ {
+		b.Run(fmt.Sprintf("%d bytes", 1<<i), func(b *testing.B) {
+			benchmarkCopyData(b, proxy, 1<<i)
+		})
+	}
+}
+
+func benchmarkCopyData(b *testing.B, proxy *Proxy, size int) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		srcIn, srcOut := net.Pipe()
+		dstIn, dstOut := net.Pipe()
+		defer func() {
+			srcIn.Close()
+			srcOut.Close()
+			dstIn.Close()
+			dstOut.Close()
+		}()
+
+		go func() {
+			buf := make([]byte, size)
+			for i := 0; i < size; i++ {
+				buf[i] = byte(i % (1 << 8))
+			}
+			_, _ = srcIn.Write(buf)
+			srcIn.Close()
+		}()
+
+		go func() {
+			var err error
+			buf := make([]byte, 1<<10)
+			for err == nil {
+				_, err = dstOut.Read(buf)
+			}
+			if err != nil && err != io.EOF && !isClosedConnectionError(err) {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+			}
+		}()
+
+		proxy.copyData(dstIn, srcOut)
+	}
+}

--- a/proxy/benchmark_test.go
+++ b/proxy/benchmark_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func BenchmarkCopyData(b *testing.B) {
-	proxy := New(nil, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
+	proxy := New(nil, 10*time.Second, 10*time.Second, 0, nil, &testLogger{}, LogEverything, false)
 
 	for i := 0; i < 16; i++ {
 		b.Run(fmt.Sprintf("%d bytes", 1<<i), func(b *testing.B) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -329,7 +328,7 @@ func (p *Proxy) copyData(dst net.Conn, src net.Conn) (written int64) {
 	if err != nil && !isClosedConnectionError(err) {
 		// We don't log individual "read from closed connection" errors, because
 		// we already have a log statement showing that a pipe has been closed.
-		if errors.Is(err, os.ErrDeadlineExceeded) {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 			connTimeoutCounter.Inc(1)
 		}
 		p.logConditional(LogConnectionErrors, "error during copy: %s", err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -41,7 +41,7 @@ func TestMultipleShutdownCalls(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.Nil(t, err, "should be able to listen on random port")
 
-	p := New(ln, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
+	p := New(ln, 10*time.Second, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
 
 	// Should not panic
 	p.Shutdown()
@@ -64,7 +64,7 @@ func TestProxySuccess(t *testing.T) {
 	}
 
 	// Start accept loop
-	p := New(incoming, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, false)
+	p := New(incoming, 10*time.Second, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, false)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -112,7 +112,7 @@ func TestProxyProtocolSuccess(t *testing.T) {
 	}
 
 	// Start accept loop
-	p := New(incoming, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, true)
+	p := New(incoming, 10*time.Second, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, true)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -164,7 +164,7 @@ func TestBackendDialError(t *testing.T) {
 		return nil, errors.New("failure for test")
 	}
 
-	p := New(ln, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, false)
+	p := New(ln, 10*time.Second, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, false)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -193,7 +193,7 @@ func TestBackendDialError(t *testing.T) {
 
 func TestCopyData(t *testing.T) {
 	size := 16 /* bytes */
-	proxy := New(nil, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
+	proxy := New(nil, 10*time.Second, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
 
 	srcIn, srcOut := net.Pipe()
 	dstIn, dstOut := net.Pipe()

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -41,7 +41,7 @@ func TestMultipleShutdownCalls(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.Nil(t, err, "should be able to listen on random port")
 
-	p := New(ln, 60*time.Second, nil, &testLogger{}, LogEverything, false)
+	p := New(ln, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
 
 	// Should not panic
 	p.Shutdown()
@@ -64,7 +64,7 @@ func TestProxySuccess(t *testing.T) {
 	}
 
 	// Start accept loop
-	p := New(incoming, 60*time.Second, dialer, &testLogger{}, LogEverything, false)
+	p := New(incoming, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, false)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -112,7 +112,7 @@ func TestProxyProtocolSuccess(t *testing.T) {
 	}
 
 	// Start accept loop
-	p := New(incoming, 60*time.Second, dialer, &testLogger{}, LogEverything, true)
+	p := New(incoming, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, true)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -164,7 +164,7 @@ func TestBackendDialError(t *testing.T) {
 		return nil, errors.New("failure for test")
 	}
 
-	p := New(ln, 60*time.Second, dialer, &testLogger{}, LogEverything, false)
+	p := New(ln, 10*time.Second, 10*time.Second, dialer, &testLogger{}, LogEverything, false)
 	go p.Accept()
 	defer p.Shutdown()
 
@@ -193,7 +193,7 @@ func TestBackendDialError(t *testing.T) {
 
 func TestCopyData(t *testing.T) {
 	size := 16 /* bytes */
-	proxy := New(nil, 60*time.Second, nil, &testLogger{}, LogEverything, false)
+	proxy := New(nil, 10*time.Second, 10*time.Second, nil, &testLogger{}, LogEverything, false)
 
 	srcIn, srcOut := net.Pipe()
 	dstIn, dstOut := net.Pipe()

--- a/proxy/str.go
+++ b/proxy/str.go
@@ -32,8 +32,11 @@ func connStatsString(forwarded, returned int64, open time.Duration) string {
 	if forwarded < 0 || returned < 0 || open == 0 {
 		return ""
 	}
+	if open > time.Millisecond {
+		open = open.Round(time.Millisecond)
+	}
 
-	return fmt.Sprintf("[forwarded %s, returned %s, open %s]", bytesWithUnit(forwarded), bytesWithUnit(returned), open.Round(time.Millisecond).String())
+	return fmt.Sprintf("[forwarded %s, returned %s, open %s]", bytesWithUnit(forwarded), bytesWithUnit(returned), open.String())
 }
 
 func peerCertificatesString(conn net.Conn) string {

--- a/proxy/str.go
+++ b/proxy/str.go
@@ -33,7 +33,7 @@ func connStatsString(forwarded, returned int64, open time.Duration) string {
 		return ""
 	}
 
-	return fmt.Sprintf("[forwarded %s, returned %s, open %s]", bytesWithUnit(forwarded), bytesWithUnit(returned), open.String())
+	return fmt.Sprintf("[forwarded %s, returned %s, open %s]", bytesWithUnit(forwarded), bytesWithUnit(returned), open.Round(time.Millisecond).String())
 }
 
 func peerCertificatesString(conn net.Conn) string {

--- a/tests/test-client-handles-client-closes-connection-unix.py
+++ b/tests/test-client-handles-client-closes-connection-unix.py
@@ -34,6 +34,14 @@ if __name__ == "__main__":
         pair.validate_closing_client_closes_server(
             "1: client closed -> server closed")
 
+        pair = SocketPair(client, TlsServer('server', 'root', 13002))
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_half_closing_client_closes_server(
+            "2: client closed -> server closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-client-handles-client-closes-connection.py
+++ b/tests/test-client-handles-client-closes-connection.py
@@ -32,6 +32,14 @@ if __name__ == "__main__":
         pair.validate_closing_client_closes_server(
             "1: client closed -> server closed")
 
+        pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_half_closing_client_closes_server(
+            "2: client closed -> server closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-client-handles-server-closes-connection-unix.py
+++ b/tests/test-client-handles-server-closes-connection-unix.py
@@ -33,6 +33,14 @@ if __name__ == "__main__":
         pair.validate_closing_server_closes_client(
             "1: server closed -> client closed")
 
+        pair = SocketPair(client, TlsServer('server', 'root', 13002))
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_half_closing_server_closes_client(
+            "2: server closed -> client closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-client-handles-server-closes-connection.py
+++ b/tests/test-client-handles-server-closes-connection.py
@@ -32,6 +32,14 @@ if __name__ == "__main__":
         pair.validate_closing_server_closes_client(
             "1: server closed -> client closed")
 
+        pair = SocketPair(TcpClient(13001), TlsServer('server', 'root', 13002))
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_half_closing_server_closes_client(
+            "2: server closed -> client closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-server-handles-client-closes-connection-unix.py
+++ b/tests/test-server-handles-client-closes-connection-unix.py
@@ -34,6 +34,14 @@ if __name__ == "__main__":
         pair.validate_closing_client_closes_server(
             "1: client closed -> server closed")
 
+        pair = SocketPair(TlsClient('client', 'root', 13001), server)
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_half_closing_client_closes_server(
+            "2: client closed -> server closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-server-handles-client-closes-connection.py
+++ b/tests/test-server-handles-client-closes-connection.py
@@ -33,6 +33,14 @@ if __name__ == "__main__":
         pair.validate_closing_client_closes_server(
             "1: client closed -> server closed")
 
+        pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13002))
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_half_closing_client_closes_server(
+            "2: client closed -> server closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-server-handles-server-closes-connection-unix.py
+++ b/tests/test-server-handles-server-closes-connection-unix.py
@@ -34,6 +34,14 @@ if __name__ == "__main__":
         pair.validate_closing_server_closes_client(
             "1: server closed -> client closed")
 
+        pair = SocketPair(TlsClient('client', 'root', 13001), server)
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_half_closing_server_closes_client(
+            "2: server closed -> client closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-server-handles-server-closes-connection.py
+++ b/tests/test-server-handles-server-closes-connection.py
@@ -33,6 +33,14 @@ if __name__ == "__main__":
         pair.validate_closing_server_closes_client(
             "1: server closed -> client closed")
 
+        pair = SocketPair(TlsClient('client', 'root', 13001), TcpServer(13000))
+        pair.validate_can_send_from_server(
+            "hello world", "2: server -> client")
+        pair.validate_can_send_from_client(
+            "hello world", "2: client -> server")
+        pair.validate_half_closing_server_closes_client(
+            "2: server closed -> client closed")
+
         print_ok("OK")
     finally:
         terminate(ghostunnel)

--- a/tests/test-server-max-conn-lifetime.py
+++ b/tests/test-server-max-conn-lifetime.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+"""
+Simulates a hanging connection, waits for timeout.
+"""
+
+from common import LOCALHOST, RootCert, STATUS_PORT, TlsClient, TcpServer, SocketPair, print_ok, run_ghostunnel, terminate, urlopen
+import urllib.request
+import urllib.error
+import urllib.parse
+import time
+import json
+
+if __name__ == "__main__":
+    ghostunnel = None
+    try:
+        # create certs
+        root = RootCert('root')
+        root.create_signed_cert('server')
+        root.create_signed_cert('new_server')
+        root.create_signed_cert('client')
+
+        # start ghostunnel
+        ghostunnel = run_ghostunnel(['server',
+                                     '--listen={0}:13000'.format(LOCALHOST),
+                                     '--target={0}:13001'.format(LOCALHOST),
+                                     '--keystore=server.p12',
+                                     '--cacert=root.crt',
+                                     '--allow-ou=client',
+                                     '--connect-timeout=10s',
+                                     '--max-conn-lifetime=1s',
+                                     '--status={0}:{1}'.format(LOCALHOST,
+                                                               STATUS_PORT)])
+
+        # wait for startup
+        TlsClient(None, 'root', STATUS_PORT).connect(20, 'server')
+
+        # create connections with client, leave connection open
+        pair1 = SocketPair(
+            TlsClient('client', 'root', 13000), TcpServer(13001))
+        pair1.validate_can_send_from_client("toto", "pair1 works")
+
+        # check metrics for connection lifetime timeout
+        timeout = False
+        for _ in range(0, 20):
+            metrics = json.loads(str(urlopen(
+                "https://{0}:{1}/_metrics".format(LOCALHOST, STATUS_PORT)).read(), 'utf-8'))
+            timeouts = [m['value']
+                        for m in metrics if "conn.timeout" in m['metric']]
+            if timeouts[0] > 0:
+                print_ok("connection timed out, as expected")
+                timeout = True
+                break
+            time.sleep(1)
+
+        if not timeout:
+            raise Exception("socket still appears to be open after timeout")
+
+        print_ok("OK")
+
+    finally:
+        terminate(ghostunnel)


### PR DESCRIPTION
Improvements to the core proxy package:
* Set up a pool of reusable buffers to reduce allocations
* Close only corresponding read, write side of connection when copying data
* Set deadline (via configurable timeout) for max conn lifetime after other side closes
* New flag for setting max conn lifetime regardless of circumstances (defaults to zero)
* Add benchmarks for the proxy package to test allocs

Before this change:
```
goos: darwin
goarch: arm64
pkg: github.com/ghostunnel/ghostunnel/proxy
cpu: Apple M1
BenchmarkCopyData/1_bytes-8         	  155918	      6713 ns/op	   36730 B/op	      31 allocs/op
BenchmarkCopyData/2_bytes-8         	  158008	      6809 ns/op	   36731 B/op	      31 allocs/op
BenchmarkCopyData/4_bytes-8         	  175996	      6766 ns/op	   36733 B/op	      31 allocs/op
BenchmarkCopyData/8_bytes-8         	  148226	      7429 ns/op	   36737 B/op	      31 allocs/op
BenchmarkCopyData/16_bytes-8        	  151615	      6977 ns/op	   36745 B/op	      31 allocs/op
BenchmarkCopyData/32_bytes-8        	  156847	      7013 ns/op	   36761 B/op	      31 allocs/op
BenchmarkCopyData/64_bytes-8        	  156166	      7003 ns/op	   36793 B/op	      31 allocs/op
BenchmarkCopyData/128_bytes-8       	  154147	      6953 ns/op	   36857 B/op	      31 allocs/op
BenchmarkCopyData/256_bytes-8       	  154548	      7029 ns/op	   36985 B/op	      31 allocs/op
BenchmarkCopyData/512_bytes-8       	  149385	      8058 ns/op	   37241 B/op	      31 allocs/op
BenchmarkCopyData/1024_bytes-8      	  145123	      7664 ns/op	   37753 B/op	      31 allocs/op
BenchmarkCopyData/2048_bytes-8      	  126390	      8548 ns/op	   38777 B/op	      31 allocs/op
BenchmarkCopyData/4096_bytes-8      	  104260	     10800 ns/op	   40825 B/op	      31 allocs/op
BenchmarkCopyData/8192_bytes-8      	   74418	     14866 ns/op	   44921 B/op	      31 allocs/op
BenchmarkCopyData/16384_bytes-8     	   51024	     22794 ns/op	   53114 B/op	      31 allocs/op
BenchmarkCopyData/32768_bytes-8     	   28970	     41048 ns/op	   69499 B/op	      31 allocs/op
PASS
ok  	github.com/ghostunnel/ghostunnel/proxy	21.014s
```

After this change:
```
goos: darwin
goarch: arm64
pkg: github.com/ghostunnel/ghostunnel/proxy
cpu: Apple M1
BenchmarkCopyData/1_bytes-8         	  279038	      4150 ns/op	    3962 B/op	      30 allocs/op
BenchmarkCopyData/2_bytes-8         	  296374	      4082 ns/op	    3962 B/op	      30 allocs/op
BenchmarkCopyData/4_bytes-8         	  300432	      4058 ns/op	    3964 B/op	      30 allocs/op
BenchmarkCopyData/8_bytes-8         	  289056	      4045 ns/op	    3968 B/op	      30 allocs/op
BenchmarkCopyData/16_bytes-8        	  293391	      4102 ns/op	    3977 B/op	      30 allocs/op
BenchmarkCopyData/32_bytes-8        	  291940	      4160 ns/op	    3992 B/op	      30 allocs/op
BenchmarkCopyData/64_bytes-8        	  293884	      4108 ns/op	    4025 B/op	      30 allocs/op
BenchmarkCopyData/128_bytes-8       	  290247	      4248 ns/op	    4088 B/op	      30 allocs/op
BenchmarkCopyData/256_bytes-8       	  286138	      4253 ns/op	    4216 B/op	      30 allocs/op
BenchmarkCopyData/512_bytes-8       	  274270	      4412 ns/op	    4473 B/op	      30 allocs/op
BenchmarkCopyData/1024_bytes-8      	  258865	      4791 ns/op	    4985 B/op	      30 allocs/op
BenchmarkCopyData/2048_bytes-8      	  196558	      6031 ns/op	    6010 B/op	      30 allocs/op
BenchmarkCopyData/4096_bytes-8      	  146282	      8132 ns/op	    8059 B/op	      30 allocs/op
BenchmarkCopyData/8192_bytes-8      	   99974	     12115 ns/op	   12155 B/op	      30 allocs/op
BenchmarkCopyData/16384_bytes-8     	   59104	     19751 ns/op	   20350 B/op	      30 allocs/op
BenchmarkCopyData/32768_bytes-8     	   31572	     37970 ns/op	   36747 B/op	      30 allocs/op
PASS
ok  	github.com/ghostunnel/ghostunnel/proxy	21.051s
```