### PR TITLE
Set read header timeout for the status HTTP server

### DIFF
--- a/main.go
+++ b/main.go
@@ -762,8 +762,9 @@ func (context *Context) serveStatus() error {
 	}
 
 	context.statusHTTP = &http.Server{
-		Handler:  mux,
-		ErrorLog: logger,
+		Handler:           mux,
+		ErrorLog:          logger,
+		ReadHeaderTimeout: *timeoutDuration,
 	}
 
 	go func() {


### PR DESCRIPTION
Use the connect timeout flag to set the read header timeout for the status HTTP server. This is an internal status endpoint, but it doesn't hurt to set the timeout here anyway.