### PR TITLE
Pin Github Actions Ubuntu image versions, update README accordingly

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         version: [1.23.x]
-    runs-on: ubuntu-latest
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up cross toolchain
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ghostunnel-linux-amd64
+          name: ghostunnel-linux-amd64-${{ matrix.os }}
           path: ghostunnel-linux-amd64
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ghostunnel-linux-arm64
+          name: ghostunnel-linux-arm64-${{ matrix.os }}
           path: ghostunnel-linux-arm64
 
   build-darwin:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   buildx:
     name: Build container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version: [1.23.x]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version: [1.23.x]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up cross toolchain
         run: |
@@ -112,7 +112,7 @@ jobs:
 
   release:
     name: Create release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build-linux, build-darwin, build-windows ]
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -135,7 +135,7 @@ jobs:
 
   add-assets-linux-darwin:
     name: Add assets for Linux/Darwin
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build-linux, build-darwin, release ]
     strategy:
       matrix:
@@ -167,7 +167,7 @@ jobs:
 
   add-assets-windows:
     name: Add assets for Windows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build-windows, release ]
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         version: [1.23.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         version: [1.23]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ a TLS-secured service. In other words, ghostunnel is a replacement for stunnel.
 including FreeBSD, OpenBSD and NetBSD. Ghostunnel also supports running on
 Windows, though with a reduced feature set. 
 
-See `ghostunnel --help`, `ghostunnel server --help` and `ghostunnel client --help`.
-
 Features
 ========
 
@@ -70,11 +68,19 @@ on how to generate new ones with OpenSSL).
 
 Ghostunnel is available through [GitHub releases][rel] and through [Docker Hub][hub].
 
-    # Compile for local architecture
+Please note that the official release binaries are best effort, and are usually
+built directly via Github Actions on the latest available images. If you need
+compatibility for specific OS versions, we recommend building yourself.
+
+To build Ghostunnel, simply run:
+
+    # Compile binary
     make ghostunnel
 
-Note that ghostunnel requires Go 1.22 or later to build, and CGO is required for
-PKCS#11 support.
+    # Generate man page
+    make ghostunnel.man
+
+Note that ghostunnel requires Go 1.22 or later to build, and CGO is required.
 
 [rel]: https://github.com/ghostunnel/ghostunnel/releases
 [hub]: https://hub.docker.com/r/ghostunnel/ghostunnel
@@ -105,8 +111,12 @@ For more information on how to contribute, please see the [CONTRIBUTING](CONTRIB
 Usage
 =====
 
-By default, ghostunnel runs in the foreground and logs to stderr. You can set
-`--syslog` to log to syslog instead of stderr. If you want to run ghostunnel
+To see available commands and flags, run `ghostunnel --help`. You can get more
+information about a command by adding `--help` to the command, like `ghostunnel
+server --help` or `ghostunnel client --help`.
+
+By default, ghostunnel runs in the foreground and logs to stdout. You can set
+`--syslog` to log to syslog instead of stdout. If you want to run ghostunnel
 in the background, we recommend using a service manager such as [systemd][systemd] or
 [runit][runit], or use a wrapper such as [daemonize][daemonize] or [dumb-init][dumb-init].
 


### PR DESCRIPTION
Fixes https://github.com/ghostunnel/ghostunnel/issues/528. Creating release builds on older versions of Ubuntu allows us to maintain compatibility with older versions of GLIBC for longer, making the official release binaries more universal. For compiling and testing, we use both old and new versions of Ubuntu.