### PR TITLE
Provide Debian-based Docker image

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -8,6 +8,26 @@ on:
     branches: [ master ]
 
 jobs:
+  build-docker:
+    name: Build (Docker)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up emulation
+        uses: docker/setup-qemu-action@v3
+      - name: Set up buildx command
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      - name: Build container (alpine)
+        run: 'docker buildx build -f Dockerfile-alpine --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+      - name: Build container (debian)
+        run: 'docker buildx build -f Dockerfile-debian --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+
   build-linux:
     name: Build (Linux)
     strategy:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,17 +16,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up emulation
-        uses: docker/setup-qemu-action@v3
       - name: Set up buildx command
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
       - name: Build container (alpine)
-        run: 'docker buildx build -f Dockerfile-alpine --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+        run: 'docker buildx build -f Dockerfile-alpine .'
       - name: Build container (debian)
-        run: 'docker buildx build -f Dockerfile-debian --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+        run: 'docker buildx build -f Dockerfile-debian .'
 
   build-linux:
     name: Build (Linux)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,9 +27,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build container (latest)
+      - name: Build container (alpine/latest)
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: 'docker buildx build --push -t ghostunnel/ghostunnel:latest --platform linux/amd64,linux/arm64,linux/arm/v7 .'
-      - name: Build container (tagged)
+        run: 'docker buildx build -f Dockerfile-alpine --push -t ghostunnel/ghostunnel:latest -t ghostunnel/ghostunnel:latest-alpine --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+      - name: Build container (debian/latest)
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: 'docker buildx build -f Dockerfile-debian --push -t ghostunnel/ghostunnel:latest-debian --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+      - name: Build container (alpine/tagged)
         if: ${{ github.ref != 'refs/heads/master' }}
-        run: 'docker buildx build --push -t ghostunnel/ghostunnel:$(git describe --tags --abbrev=0) --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+        run: 'docker buildx build --push -t ghostunnel/ghostunnel:$(git describe --tags --abbrev=0) -t ghostunnel/ghostunnel:$(git describe --tags --abbrev=0)-alpine --platform linux/amd64,linux/arm64,linux/arm/v7 .'
+      - name: Build container (debian/tagged)
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: 'docker buildx build --push -t ghostunnel/ghostunnel:$(git describe --tags --abbrev=0)-debian --platform linux/amd64,linux/arm64,linux/arm/v7 .'

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-# Dockerfile for ghostunnel/ghostunnel, useful as a basis for other images.
+# Dockerfile for ghostunnel/ghostunnel built on Alpine.
 #
 # To build this image:
 #     docker build -t ghostunnel/ghostunnel .
@@ -6,7 +6,7 @@
 # To run ghostunnel from the image (for example):
 #     docker run --rm ghostunnel/ghostunnel --version
 
-FROM golang:1.23-alpine as build
+FROM golang:1.23-alpine AS build
 
 # Dependencies
 RUN apk add --no-cache --update gcc musl-dev libtool make git

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,0 +1,28 @@
+# Dockerfile for ghostunnel/ghostunnel built on Debian.
+#
+# To build this image:
+#     docker build -t ghostunnel/ghostunnel .
+#
+# To run ghostunnel from the image (for example):
+#     docker run --rm ghostunnel/ghostunnel --version
+
+FROM golang:1.23-bookworm AS build
+
+# Dependencies
+RUN apt update && apt upgrade && apt install -y gcc libtool make git
+
+# Copy source
+COPY . /go/src/github.com/ghostunnel/ghostunnel
+
+# Build
+RUN cd /go/src/github.com/ghostunnel/ghostunnel && \
+    GO111MODULE=on make clean ghostunnel && \
+    cp ghostunnel /usr/bin/ghostunnel
+
+# Create a multi-stage build with the binary
+FROM debian:bookworm-slim
+
+RUN apt update && apt upgrade && apt install -y libtool curl
+COPY --from=build /usr/bin/ghostunnel /usr/bin/ghostunnel
+
+ENTRYPOINT ["/usr/bin/ghostunnel"]


### PR DESCRIPTION
Provide Debian-based Docker image, alongside Alpine. Some folks may prefer Debian (glibc) instead of Alpine (musl) as their base image. We also add a new build job in `compile.yml` to build the Docker images on pull requests, not just after merge. 