### PR TITLE
Improve proxy logging

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -278,7 +278,8 @@ func (p *Proxy) logConditional(flag int, msg string, args ...interface{}) {
 func isClosedConnectionError(err error) bool {
 	opErr := &net.OpError{}
 	if errors.As(err, &opErr) {
-		return (opErr.Op == "read" || opErr.Op == "readfrom") && strings.Contains(err.Error(), "closed network connection")
+		return (opErr.Op == "read" || opErr.Op == "readfrom" || opErr.Op == "write" || opErr.Op == "writeto") &&
+			strings.Contains(err.Error(), "closed network connection")
 	}
 	return false
 }

--- a/proxy/str.go
+++ b/proxy/str.go
@@ -28,12 +28,12 @@ func bytesWithUnit(n int64) string {
 	return fmt.Sprintf("%1.1f EiB", float32(n)/float32(1024))
 }
 
-func connStatsString(sent, recv int64, open time.Duration) string {
-	if sent < 0 || recv < 0 || open == 0 {
+func connStatsString(forwarded, returned int64, open time.Duration) string {
+	if forwarded < 0 || returned < 0 || open == 0 {
 		return ""
 	}
 
-	return fmt.Sprintf("[sent %s, recv %s, open %s]", bytesWithUnit(sent), bytesWithUnit(recv), open.String())
+	return fmt.Sprintf("[forwarded %s, returned %s, open %s]", bytesWithUnit(forwarded), bytesWithUnit(returned), open.String())
 }
 
 func peerCertificatesString(conn net.Conn) string {

--- a/proxy/str.go
+++ b/proxy/str.go
@@ -1,0 +1,49 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"time"
+)
+
+var byteUnits []string = []string{
+	"KiB",
+	"MiB",
+	"GiB",
+	"TiB",
+	"PiB",
+}
+
+func bytesWithUnit(n int64) string {
+	if n < (1 << 10) {
+		return fmt.Sprintf("%d bytes", n)
+	}
+	for _, unit := range byteUnits {
+		if n < (1 << 20) {
+			return fmt.Sprintf("%1.1f %s", float32(n)/float32(1024), unit)
+		}
+		n = n >> 10
+	}
+	return fmt.Sprintf("%1.1f EiB", float32(n)/float32(1024))
+}
+
+func connStatsString(sent, recv int64, open time.Duration) string {
+	if sent < 0 || recv < 0 || open == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("[sent %s, recv %s, open %s]", bytesWithUnit(sent), bytesWithUnit(recv), open.String())
+}
+
+func peerCertificatesString(conn net.Conn) string {
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		if len(tlsConn.ConnectionState().PeerCertificates) > 0 {
+			return tlsConn.ConnectionState().PeerCertificates[0].Subject.String()
+		}
+
+		return "no cert"
+	}
+
+	return "no tls"
+}

--- a/proxy/str_test.go
+++ b/proxy/str_test.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	"math"
+	"testing"
+)
+
+func TestBytesWithUnit(t *testing.T) {
+	cases := []struct {
+		n        int64
+		expected string
+	}{
+		{0, "0 bytes"},
+		{1, "1 bytes"},
+		{1 << 9, "512 bytes"},
+		{1<<10 - 1, "1023 bytes"},
+		{1 << 10, "1.0 KiB"},
+		{1<<10 + 1<<9, "1.5 KiB"},
+		{1 << 19, "512.0 KiB"},
+		{1 << 20, "1.0 MiB"},
+		{1<<20 + 1<<19, "1.5 MiB"},
+		{1 << 29, "512.0 MiB"},
+		{1 << 30, "1.0 GiB"},
+		{1<<30 + 1<<29, "1.5 GiB"},
+		{1 << 39, "512.0 GiB"},
+		{1 << 40, "1.0 TiB"},
+		{1<<40 + 1<<39, "1.5 TiB"},
+		{1 << 49, "512.0 TiB"},
+		{1 << 50, "1.0 PiB"},
+		{1<<50 + 1<<49, "1.5 PiB"},
+		{1 << 59, "512.0 PiB"},
+		{1 << 60, "1.0 EiB"},
+		{1<<60 + 1<<59, "1.5 EiB"},
+		{math.MaxInt64, "8.0 EiB"},
+	}
+
+	for _, c := range cases {
+		result := bytesWithUnit(c.n)
+		if result != c.expected {
+			t.Errorf("%d: got %s, wanted %s", c.n, result, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
Changes:
- Log bytes sent, received, and conn open time
- Ignore more closed connection errors (not just on "read") -- don't think these were useful

Example client log:
```
[39263] 2025/02/09 14:24:54.102740 starting ghostunnel in client mode
[39263] 2025/02/09 14:24:54.103382 using keystore file on disk as certificate source
[39263] 2025/02/09 14:24:54.104632 using target address localhost:8003
[39263] 2025/02/09 14:24:54.104998 listening for connections on localhost:8002
[39263] 2025/02/09 14:24:59.126954 opening pipe: tcp:127.0.0.1:57372 [no tls] <-> tcp:127.0.0.1:8003 [CN=server]
[39263] 2025/02/09 14:25:00.635175 closed pipe: tcp:127.0.0.1:57372 [no tls] <-> tcp:127.0.0.1:8003 [CN=server] [forwarded 398.3 KiB, returned 0 bytes, open 1.508188167s]
```

Example server log:
```
[39265] 2025/02/09 14:24:55.396168 starting ghostunnel in server mode
[39265] 2025/02/09 14:24:55.396434 using keystore file on disk as certificate source
[39265] 2025/02/09 14:24:55.397984 using target address localhost:8004
[39265] 2025/02/09 14:24:55.398502 listening for connections on localhost:8003
[39265] 2025/02/09 14:24:59.127615 opening pipe: tcp:127.0.0.1:57373 [CN=client] <-> tcp:127.0.0.1:8004 [no tls]
[39265] 2025/02/09 14:25:00.635235 closed pipe: tcp:127.0.0.1:57373 [CN=client] <-> tcp:127.0.0.1:8004 [no tls] [forwarded 398.3 KiB, returned 0 bytes, open 1.507570916s]
```