### PR TITLE
Show a bit more information in status line/endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -493,7 +493,7 @@ func run(args []string) error {
 		}
 		logger.Printf("using target address %s", *serverForwardAddress)
 
-		status := newStatusHandler(dial, *serverStatusTargetAddress)
+		status := newStatusHandler(dial, command, *serverListenAddress, *serverForwardAddress, *serverStatusTargetAddress)
 		context := &Context{
 			status:          status,
 			shutdownChannel: make(chan bool, 1),
@@ -542,10 +542,10 @@ func run(args []string) error {
 			return err
 		}
 
-		// NOTE: We don't provide a target status address here because this the client
-		// /_status endpoint and therefore, its target will be a ghostunnel in server
-		// mode and therefore, should be a (default) TCP check.
-		status := newStatusHandler(dial, "")
+		// NOTE: We don't provide a target status address here because this handler
+		// is for the client /_status endpoint, its target will be a Ghostunnel in
+		// server mode, and thus this should be a (default) TCP check.
+		status := newStatusHandler(dial, command, *clientListenAddress, *clientForwardAddress, "")
 		context := &Context{
 			status:          status,
 			shutdownChannel: make(chan bool, 1),

--- a/status_test.go
+++ b/status_test.go
@@ -126,7 +126,7 @@ func TestStatusHandleWatchdog(t *testing.T) {
 }
 
 func TestStatusHandlerNew(t *testing.T) {
-	handler := newStatusHandler(dummyDial, "")
+	handler := newStatusHandler(dummyDial, "", "", "", "")
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, nil)
 
@@ -140,7 +140,7 @@ func TestStatusHandlerNew(t *testing.T) {
 }
 
 func TestStatusHandlerListeningTCP(t *testing.T) {
-	handler := newStatusHandler(dummyDial, "")
+	handler := newStatusHandler(dummyDial, "", "", "", "")
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.ServeHTTP(response, nil)
@@ -155,7 +155,7 @@ func TestStatusHandlerListeningTCP(t *testing.T) {
 }
 
 func TestStatusHandlerListeningBackendDown(t *testing.T) {
-	handler := newStatusHandler(dummyDialError, "")
+	handler := newStatusHandler(dummyDialError, "", "", "", "")
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.ServeHTTP(response, nil)
@@ -166,7 +166,7 @@ func TestStatusHandlerListeningBackendDown(t *testing.T) {
 }
 
 func TestStatusHandlerReloading(t *testing.T) {
-	handler := newStatusHandler(dummyDial, "")
+	handler := newStatusHandler(dummyDial, "", "", "", "")
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.Reloading()
@@ -178,7 +178,7 @@ func TestStatusHandlerReloading(t *testing.T) {
 }
 
 func TestStatusHandlerStopping(t *testing.T) {
-	handler := newStatusHandler(dummyDial, "")
+	handler := newStatusHandler(dummyDial, "", "", "", "")
 	response := httptest.NewRecorder()
 	handler.Listening()
 	handler.Stopping()
@@ -190,7 +190,7 @@ func TestStatusHandlerStopping(t *testing.T) {
 }
 
 func TestStatusHandlerResponses(t *testing.T) {
-	handler := newStatusHandler(dummyDial, "")
+	handler := newStatusHandler(dummyDial, "", "", "", "")
 	resp := handler.status()
 	if resp.Message != "initializing" {
 		t.Error("status should say 'initializing' on startup")

--- a/status_test.go
+++ b/status_test.go
@@ -253,7 +253,7 @@ func statusTargetWithResponseStatusCode(code int) (statusResponse, int) {
 		}
 		u, _ := url.Parse(statusTarget.URL) // NOTE: I tried using statusTarget.Config.Addr instead, but it wasn't set.
 		return net.Dial("tcp", fmt.Sprintf("%s:%s", u.Hostname(), u.Port()))
-	}, statusTarget.URL)
+	}, "", "", "", statusTarget.URL)
 
 	req := httptest.NewRequest(http.MethodGet, "/not-empty", nil)
 	handler.Listening() // NOTE: required for non-503 backend response code.


### PR DESCRIPTION
Adds the listening & forward addresses to the status line in systemd, and in the status endpoint. This should help distinguish different ghostunnel processes from each other, if there's more than one running on a machine. 

Example for systemd (status now shows better info):
```
● ghostunnel.service - Ghostunnel
     Loaded: loaded (/etc/systemd/system/ghostunnel.service; disabled; preset: enabled)
     Active: active (running) since Fri 2025-03-28 15:54:47 PDT; 1 day 23h ago
   Main PID: 7945 (ghostunnel)
     Status: "listening | server proxying localhost:9443 => localhost:9080"
      Tasks: 10 (limit: 18907)
     Memory: 10.4M (peak: 12.0M)
        CPU: 6min 52.654s
```

Example output of status endpoint:
```
{
  "ok": false,
  "status": "critical",
  "listen_address": "localhost:9443",
  "forward_address": "localhost:9080",
  "backend_ok": false,
  "backend_status": "critical",
  "backend_error": "dial tcp 127.0.0.1:9080: connect: connection refused",
  "time": "2025-03-30T15:14:56.050490016-07:00",
  "last_reload": "0001-01-01T00:00:00Z",
  "hostname": "capsule",
  "message": "listening",
  "revision": "v1.8.4-34-g6e4b0624-dirty",
  "compiler": "go1.24.0"
}
```

Also, this makes a slight change where we skip the logging of connections earlier to save us time computing stats about the connection if we're not going to print it anyway. 
