### PR TITLE
Set default close timeout to 1s, closer to old behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ var (
 	timedReload            = app.Flag("timed-reload", "Reload keystores every given interval (e.g. 300s), refresh listener/client on changes.").PlaceHolder("DURATION").Duration()
 	processShutdownTimeout = app.Flag("shutdown-timeout", "Process shutdown timeout. Terminates after timeout even if connections still open.").Default("5m").Duration()
 	connectTimeout         = app.Flag("connect-timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
-	closeTimeout           = app.Flag("close-timeout", "Timeout for closing connections when one side terminates.").Default("10s").Duration()
+	closeTimeout           = app.Flag("close-timeout", "Timeout for closing connections when one side terminates. Zero means immediate closure.").Default("1s").Duration()
 	maxConnLifetime        = app.Flag("max-conn-lifetime", "Maximum lifetime for connections post handshake, no matter what. Zero means infinite.").Default("0s").Duration()
 	maxConcurrentConns     = app.Flag("max-concurrent-conns", "Maximum number of concurrent connections to handle in the proxy. Zero means infinite.").Default("0").Uint32()
 


### PR DESCRIPTION
Set default close timeout to 1s, closer to old behavior. (Old behavior was equivalent to 0s)