### PR TITLE
Add flag to skip DNS resolution on startup, fixes #585

### DIFF
--- a/socket/net.go
+++ b/socket/net.go
@@ -52,15 +52,12 @@ func ParseAddress(input string, skipResolve bool) (network, address, host string
 		return
 	}
 
+	network, address = "tcp", input
 	if !skipResolve {
 		// Make sure target address resolves, unless requested otherwise.
 		_, err = net.ResolveTCPAddr("tcp", input)
-		if err != nil {
-			return
-		}
 	}
 
-	network, address = "tcp", input
 	return
 }
 


### PR DESCRIPTION
Add flag to skip DNS resolution on startup, fixes #585.

---

<!-- kody-pr-summary:start -->
This pull request introduces a new `--skip-resolve` command-line flag to Ghostunnel, allowing it to start without immediately resolving target hostnames. This is particularly useful when Ghostunnel needs to be launched before the network is fully operational or DNS services are available.

Key changes include:

*   **New `--skip-resolve` flag**: When enabled, Ghostunnel will defer DNS resolution for the client's forward address and the server's backend forward address until a connection attempt is made, rather than failing on startup if resolution is not possible.
*   **Client Mode**: The client will now skip initial DNS resolution for its target address if `--skip-resolve` is set or if a client proxy is configured.
*   **Server Mode**: The server will now skip initial DNS resolution for its backend forward address if `--skip-resolve` is set.
*   **Status Server**: DNS resolution for the status server's bind address is now always skipped, preventing startup failures related to resolving local bind addresses (e.g., `0.0.0.0`).
<!-- kody-pr-summary:end -->