### PR TITLE
Build on Go 1.25

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build (Linux)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
         os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,7 +70,7 @@ jobs:
     name: Build (MacOS)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
     runs-on: macos-latest
     steps:
       - name: Set up toolchain
@@ -111,7 +111,7 @@ jobs:
     name: Build (Windows)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
     runs-on: windows-latest
     steps:
       - name: Set up toolchain

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build (Linux)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
     runs-on: ubuntu-22.04
     steps:
       - name: Set up cross toolchain
@@ -48,7 +48,7 @@ jobs:
     name: Build (MacOS)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
     runs-on: macos-latest
     steps:
       - name: Set up toolchain
@@ -88,7 +88,7 @@ jobs:
     name: Build (Windows)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
     runs-on: windows-latest
     steps:
       - name: Set up toolchain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
         os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,7 +32,7 @@ jobs:
     name: Integration tests (Linux)
     strategy:
       matrix:
-        version: [1.24]
+        version: [1.25]
         os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
@@ -56,7 +56,7 @@ jobs:
     name: Integration tests (Darwin)
     strategy:
       matrix:
-        version: [1.24.x]
+        version: [1.25.x]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -6,7 +6,7 @@
 # To run ghostunnel from the image (for example):
 #     docker run --rm ghostunnel/ghostunnel --version
 
-FROM golang:1.24-alpine AS build
+FROM golang:1.25-alpine AS build
 
 # Dependencies
 RUN apk add --no-cache --update gcc musl-dev libtool make git

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -6,7 +6,7 @@
 # To run ghostunnel from the image (for example):
 #     docker run --rm ghostunnel/ghostunnel --version
 
-FROM golang:1.24-bookworm AS build
+FROM golang:1.25-bookworm AS build
 
 # Dependencies
 RUN apt update && apt install -y gcc libtool make git

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -6,7 +6,7 @@
 # Run integration tests:
 #     docker run -v /dev/log:/dev/log -v $PWD:/go/src/github.com/ghostunnel/ghostunnel ghostunnel/ghostunnel-test
 
-ARG GO_VERSION="1.24"
+ARG GO_VERSION="1.25"
 
 FROM golang:${GO_VERSION}
 


### PR DESCRIPTION
Build on Go 1.25

---

<!-- kody-pr-summary:start -->
Updates all GitHub Actions workflows (compile, lint, release, test) and Dockerfiles (Alpine, Debian, test) to use Go 1.25. This change migrates the project's build, test, and packaging infrastructure to the Go 1.25 toolchain.
<!-- kody-pr-summary:end -->