### PR TITLE
Fix golangci-lint govet issues

### DIFF
--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -445,8 +445,8 @@ func mapToCFDictionary(gomap map[C.CFTypeRef]C.CFTypeRef) C.CFDictionaryRef {
 	)
 
 	for k, v := range gomap {
-		keys = append(keys, unsafe.Pointer(k))
-		values = append(values, unsafe.Pointer(v))
+		keys = append(keys, unsafe.Pointer(k))     //nolint:govet // CGo pointer conversion is safe here
+		values = append(values, unsafe.Pointer(v)) //nolint:govet // CGo pointer conversion is safe here
 	}
 
 	return C.CFDictionaryCreate(nilCFAllocatorRef, &keys[0], &values[0], C.CFIndex(n), nil, nil)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -191,8 +191,8 @@ func (p *Proxy) Accept() {
 			continue
 		}
 
+		p.handlers.Add(1)
 		go connTimer.Time(func() {
-			p.handlers.Add(1)
 			openCounter.Inc(1)
 			totalCounter.Inc(1)
 

--- a/status_test.go
+++ b/status_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -253,7 +252,7 @@ func statusTargetWithResponseStatusCode(code int) (statusResponse, int) {
 			return nil, errors.New("simulating error when talking to backend")
 		}
 		u, _ := url.Parse(statusTarget.URL) // NOTE: I tried using statusTarget.Config.Addr instead, but it wasn't set.
-		return net.Dial("tcp", fmt.Sprintf("%s:%s", u.Hostname(), u.Port()))
+		return net.Dial("tcp", net.JoinHostPort(u.Hostname(), u.Port()))
 	}, "", "", "", statusTarget.URL)
 
 	req := httptest.NewRequest(http.MethodGet, "/not-empty", nil)


### PR DESCRIPTION
- Move WaitGroup.Add before goroutine in proxy.go to fix race condition
- Use net.JoinHostPort for IPv6 compatibility in status_test.go
- Add nolint directives for CGo pointer conversions in certstore_darwin.go