### PR TITLE
Add macOS codesigning, notarization, and Docker tag improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,24 @@ jobs:
           CGO_ENABLED=1 GOARCH=arm64 ./mage-bin -v go:build
           mv ghostunnel ghostunnel-darwin-arm64
           lipo -create -output ghostunnel-darwin-universal ghostunnel-darwin-amd64 ghostunnel-darwin-arm64
+      - name: Codesign binaries
+        env:
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+          CODESIGN_CERTIFICATE: ${{ secrets.CODESIGN_CERTIFICATE }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+        run: |
+          ./mage-bin -v apple:codesign ghostunnel-darwin-amd64
+          ./mage-bin -v apple:codesign ghostunnel-darwin-arm64
+          ./mage-bin -v apple:codesign ghostunnel-darwin-universal
+      - name: Notarize binaries
+        env:
+          NOTARIZE_ISSUER_ID: ${{ secrets.NOTARIZE_ISSUER_ID }}
+          NOTARIZE_KEY_ID: ${{ secrets.NOTARIZE_KEY_ID }}
+          NOTARIZE_KEY: ${{ secrets.NOTARIZE_KEY }}
+        run: |
+          ./mage-bin -v apple:notarize ghostunnel-darwin-amd64
+          ./mage-bin -v apple:notarize ghostunnel-darwin-arm64
+          ./mage-bin -v apple:notarize ghostunnel-darwin-universal
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
Add apple:codesign and apple:notarize mage targets for signing and notarizing macOS binaries. Codesign uses the macOS codesign tool with hardened runtime enabled. Notarize submits to Apple's notary service via xcrun notarytool with App Store Connect API key auth.

For CI, CODESIGN_CERTIFICATE (base64 .p12) triggers temporary keychain creation with automatic cleanup. NOTARIZE_KEY (base64 .p8) is written to a temp file for notarytool. Sensitive security commands use runSilent to suppress argument echoing in CI logs.

Add codesign and notarize steps to the Darwin release workflow.

Change Docker tagging so "latest" is only applied on release tag pushes (e.g. v1.9.0), not on master branch pushes. Master pushes now produce "master" tagged images instead.