### PR TITLE
Print SKIP status for skipped integration tests

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
+          cache: false
       - name: Build containers
         run: go tool mage -v docker:build
         env:
@@ -49,6 +50,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6
@@ -84,6 +86,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6
@@ -125,6 +128,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
+          cache: false
       - name: Login to Docker Hub
         uses: docker/login-action@v4 
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,5 +21,6 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
       - name: golangci-lint
         run: go tool mage go:lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,6 +61,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6
@@ -120,6 +122,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
         id: go
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,6 +61,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.version }}
+          cache: false
       - name: Run tests in Docker
         run: GO_VERSION=${{ matrix.version }} go tool mage -v test:docker
       - name: Codecov upload

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:

--- a/magefile.go
+++ b/magefile.go
@@ -481,6 +481,7 @@ func (Test) Integration(ctx context.Context) error {
 			defer func() { <-sem }() // release
 
 			testName := strings.TrimSuffix(filepath.Base(testFile), ".py")
+			printf("=== RUN   %s\n", testName)
 
 			start := time.Now()
 			testFileName := filepath.Base(testFile)
@@ -509,11 +510,12 @@ func (Test) Integration(ctx context.Context) error {
 	for i := 0; i < len(testFiles); i++ {
 		r := <-results
 		if r.err == nil {
-			printf("=== PASS: %s (%.2fs)\n", r.name, r.duration.Seconds())
+			printf("--- PASS: %s (%.2fs)\n", r.name, r.duration.Seconds())
 		} else if exitErr, ok := r.err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
-			printf("=== SKIP: %s (%.2fs) %s\n", r.name, r.duration.Seconds(), strings.TrimSpace(string(r.stdout)))
+			reason := strings.SplitN(strings.TrimSpace(string(r.stderr)), "\n", 2)[0]
+			printf("--- SKIP: %s (%.2fs) (%s)\n", r.name, r.duration.Seconds(), reason)
 		} else {
-			fmt.Printf("=== FAIL: %s (%.2fs)\n", r.name, r.duration.Seconds())
+			fmt.Printf("--- FAIL: %s (%.2fs)\n", r.name, r.duration.Seconds())
 			failed = append(failed, r)
 		}
 	}
@@ -522,7 +524,7 @@ func (Test) Integration(ctx context.Context) error {
 	if len(failed) > 0 {
 		fmt.Printf("\n--- FAILURES ---\n")
 		for _, r := range failed {
-			fmt.Printf("\n=== FAIL: %s (%.2fs)\n", r.name, r.duration.Seconds())
+			fmt.Printf("\n--- FAIL: %s (%.2fs)\n", r.name, r.duration.Seconds())
 			fmt.Printf("--- stdout ---\n")
 			os.Stdout.Write(r.stdout)
 			fmt.Printf("--- stderr ---\n")
@@ -580,7 +582,7 @@ func (Test) Single(ctx context.Context, name string) error {
 	elapsed := time.Since(start).Seconds()
 
 	if err == nil {
-		printf("=== PASS: %s (%.2fs)\n", name, elapsed)
+		printf("--- PASS: %s (%.2fs)\n", name, elapsed)
 		return nil
 	}
 
@@ -591,7 +593,7 @@ func (Test) Single(ctx context.Context, name string) error {
 		fmt.Printf("--- stderr ---\n")
 		os.Stdout.Write(stderr.Bytes())
 	}
-	fmt.Printf("=== FAIL: %s (%.2fs)\n", name, elapsed)
+	fmt.Printf("--- FAIL: %s (%.2fs)\n", name, elapsed)
 	if exitError, ok := err.(*exec.ExitError); ok {
 		return fmt.Errorf("integration test %s failed with exit code %d", name, exitError.ExitCode())
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -510,6 +510,8 @@ func (Test) Integration(ctx context.Context) error {
 		r := <-results
 		if r.err == nil {
 			printf("=== PASS: %s (%.2fs)\n", r.name, r.duration.Seconds())
+		} else if exitErr, ok := r.err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			printf("=== SKIP: %s (%.2fs) %s\n", r.name, r.duration.Seconds(), strings.TrimSpace(string(r.stdout)))
 		} else {
 			fmt.Printf("=== FAIL: %s (%.2fs)\n", r.name, r.duration.Seconds())
 			failed = append(failed, r)

--- a/tests/common.py
+++ b/tests/common.py
@@ -353,20 +353,20 @@ def check_ed25519_support():
         check_output('openssl genpkey -algorithm ed25519 -out {0}'.format(devnull),
                      shell=True, stderr=DEVNULL)
     except Exception:
-        print_ok("SKIP (OpenSSL does not support ED25519)")
-        sys.exit(0)
+        print("OpenSSL does not support ED25519")
+        sys.exit(2)
 
 def check_keytool():
     """Skip the test if keytool is not available."""
     if not shutil.which('keytool'):
-        print_ok("SKIP (keytool not available)")
-        sys.exit(0)
+        print("keytool not available")
+        sys.exit(2)
 
 def skip_on_windows(reason="not supported on Windows"):
     """Skip the test on Windows."""
     if IS_WINDOWS:
-        print_ok("SKIP ({0})".format(reason))
-        sys.exit(0)
+        print(reason)
+        sys.exit(2)
 
 def reload_args():
     """Extra args to enable certificate reload on Windows via --timed-reload."""
@@ -389,7 +389,7 @@ def trigger_reload(ghostunnel):
 
 def convert_p12_to_jceks(p12_name, jceks_name, password):
     """Convert a PKCS#12 keystore to JCEKS format using keytool.
-    Skips the test (sys.exit(0)) if the conversion fails."""
+    Skips the test (sys.exit(2)) if the conversion fails."""
     try:
         os.remove('{0}.jceks'.format(jceks_name))
     except OSError:
@@ -400,8 +400,8 @@ def convert_p12_to_jceks(p12_name, jceks_name, password):
                '-noprompt'.format(p12_name, jceks_name, password),
                shell=True, stderr=DEVNULL)
     if ret != 0:
-        print_ok("SKIP (keytool -importkeystore failed)")
-        sys.exit(0)
+        print("keytool -importkeystore failed")
+        sys.exit(2)
 
 def print_ok(msg):
     print("\033[92m{0}\033[0m".format(msg))

--- a/tests/common.py
+++ b/tests/common.py
@@ -353,19 +353,19 @@ def check_ed25519_support():
         check_output('openssl genpkey -algorithm ed25519 -out {0}'.format(devnull),
                      shell=True, stderr=DEVNULL)
     except Exception:
-        print("OpenSSL does not support ED25519")
+        print("OpenSSL does not support ED25519", file=sys.stderr)
         sys.exit(2)
 
 def check_keytool():
     """Skip the test if keytool is not available."""
     if not shutil.which('keytool'):
-        print("keytool not available")
+        print("keytool not available", file=sys.stderr)
         sys.exit(2)
 
 def skip_on_windows(reason="not supported on Windows"):
     """Skip the test on Windows."""
     if IS_WINDOWS:
-        print(reason)
+        print(reason, file=sys.stderr)
         sys.exit(2)
 
 def reload_args():
@@ -400,7 +400,7 @@ def convert_p12_to_jceks(p12_name, jceks_name, password):
                '-noprompt'.format(p12_name, jceks_name, password),
                shell=True, stderr=DEVNULL)
     if ret != 0:
-        print("keytool -importkeystore failed")
+        print("keytool -importkeystore failed", file=sys.stderr)
         sys.exit(2)
 
 def print_ok(msg):

--- a/tests/test-client-systemd-socket-activation.py
+++ b/tests/test-client-systemd-socket-activation.py
@@ -13,7 +13,7 @@ skip_on_windows("requires systemd")
 ghostunnel = None
 
 if not which('systemd-socket-activate'):
-    print('no systemd-socket-activate binary found')
+    print('no systemd-socket-activate binary found', file=sys.stderr)
     sys.exit(2)
 
 try:

--- a/tests/test-client-systemd-socket-activation.py
+++ b/tests/test-client-systemd-socket-activation.py
@@ -13,8 +13,8 @@ skip_on_windows("requires systemd")
 ghostunnel = None
 
 if not which('systemd-socket-activate'):
-    print_ok('skipping systemd socket activation test, no systemd-socket-activate binary found')
-    sys.exit(0)
+    print('no systemd-socket-activate binary found')
+    sys.exit(2)
 
 try:
     # create certs

--- a/tests/test-server-pkcs11-module.py
+++ b/tests/test-server-pkcs11-module.py
@@ -16,7 +16,7 @@ ghostunnel = None
 try:
     # Only run PKCS11 tests if requested
     if 'GHOSTUNNEL_TEST_PKCS11' not in os.environ:
-        print('GHOSTUNNEL_TEST_PKCS11 not set')
+        print('GHOSTUNNEL_TEST_PKCS11 not set', file=sys.stderr)
         sys.exit(2)
 
     test_keys = os.path.join(_ROOT_DIR, 'test-keys')

--- a/tests/test-server-pkcs11-module.py
+++ b/tests/test-server-pkcs11-module.py
@@ -16,7 +16,8 @@ ghostunnel = None
 try:
     # Only run PKCS11 tests if requested
     if 'GHOSTUNNEL_TEST_PKCS11' not in os.environ:
-        sys.exit(0)
+        print('GHOSTUNNEL_TEST_PKCS11 not set')
+        sys.exit(2)
 
     test_keys = os.path.join(_ROOT_DIR, 'test-keys')
     copyfile(os.path.join(test_keys, 'client-key.pem'), 'client.key')


### PR DESCRIPTION
Skipped integration tests (e.g. missing keytool, Windows-only) used to
exit 0 and show up as PASS in the mage output, making it hard to tell
what actually ran. Now they exit 2 and print SKIP with the reason.