### PR TITLE
Fix small bugs found by Claude

### DIFF
--- a/certloader/acmetlsconfig.go
+++ b/certloader/acmetlsconfig.go
@@ -49,6 +49,7 @@ type ACMEConfig struct {
 	MaxAttempts int
 }
 
+// TLSConfigSourceFromACME creates a TLSConfigSource that obtains certificates via ACME.
 func TLSConfigSourceFromACME(acme *ACMEConfig) (TLSConfigSource, error) {
 	certmagic.DefaultACME.DisableHTTPChallenge = true
 	certmagic.DefaultACME.Agreed = acme.TOSAgreed

--- a/certloader/decode.go
+++ b/certloader/decode.go
@@ -153,7 +153,7 @@ func readDERBlocks(reader io.Reader) ([]*pem.Block, error) {
 		return blocks, nil
 	}
 
-	return nil, fmt.Errorf("unable to parse DER data as X.509 (%v) or PKCS7 (%v)", err0, err1)
+	return nil, fmt.Errorf("unable to parse DER data as X.509 (%w) or PKCS7 (%w)", err0, err1)
 }
 
 func readPKCS12Blocks(reader io.Reader, password string) ([]*pem.Block, error) {

--- a/certloader/jceks/modutf8.go
+++ b/certloader/jceks/modutf8.go
@@ -48,7 +48,7 @@ func readModifiedUTF8(r io.Reader) (string, error) {
 		var err error
 		buf[0], err = br.ReadByte()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 
@@ -70,7 +70,7 @@ func readModifiedUTF8(r io.Reader) (string, error) {
 
 		buf[1], err = br.ReadByte()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = io.ErrUnexpectedEOF
 			}
 
@@ -97,7 +97,7 @@ func readModifiedUTF8(r io.Reader) (string, error) {
 
 		buf[2], err = br.ReadByte()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = io.ErrUnexpectedEOF
 			}
 

--- a/certloader/tlsconfig.go
+++ b/certloader/tlsconfig.go
@@ -39,8 +39,8 @@ type TLSConfigSource interface {
 
 	// GetServerConfig returns a TLSServerConfig interface that can be used to
 	// obtain TLS server configuration. The base configuration is cloned and
-	// used as a base for all returned TLS configuration. If the TLSConfig is
-	// not appropriate for use as a server, false is returned.
+	// used as a base for all returned TLS configuration. If the source is
+	// not appropriate for use as a server, an error is returned.
 	GetServerConfig(base *tls.Config) (TLSServerConfig, error)
 }
 

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -120,8 +121,8 @@ func (s macStore) Close() {}
 type macIdentity struct {
 	mu    sync.Mutex
 	ref   C.SecIdentityRef
-	kref  C.SecKeyRef
-	cref  C.SecCertificateRef
+	kref  atomic.Uintptr
+	cref  atomic.Uintptr
 	crt   *x509.Certificate
 	chain []*x509.Certificate
 }
@@ -251,14 +252,12 @@ func (i *macIdentity) Close() {
 		i.ref = nilSecIdentityRef
 	}
 
-	if i.kref != nilSecKeyRef {
-		C.CFRelease(C.CFTypeRef(i.kref))
-		i.kref = nilSecKeyRef
+	if kref := C.SecKeyRef(i.kref.Swap(uintptr(nilSecKeyRef))); kref != nilSecKeyRef {
+		C.CFRelease(C.CFTypeRef(kref))
 	}
 
-	if i.cref != nilSecCertificateRef {
-		C.CFRelease(C.CFTypeRef(i.cref))
-		i.cref = nilSecCertificateRef
+	if cref := C.SecCertificateRef(i.cref.Swap(uintptr(nilSecCertificateRef))); cref != nilSecCertificateRef {
+		C.CFRelease(C.CFTypeRef(cref))
 	}
 }
 
@@ -389,15 +388,15 @@ func (i *macIdentity) getAlgo(hash crypto.Hash, opts crypto.SignerOpts) (algo C.
 
 // getKeyRef gets the SecKeyRef for this identity's private key.
 func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
-	if i.kref != nilSecKeyRef {
-		return i.kref, nil
+	if kref := C.SecKeyRef(i.kref.Load()); kref != nilSecKeyRef {
+		return kref, nil
 	}
 
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	if i.kref != nilSecKeyRef {
-		return i.kref, nil
+	if kref := C.SecKeyRef(i.kref.Load()); kref != nilSecKeyRef {
+		return kref, nil
 	}
 
 	var keyRef C.SecKeyRef
@@ -405,22 +404,22 @@ func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
 		return nilSecKeyRef, err
 	}
 
-	i.kref = keyRef
+	i.kref.Store(uintptr(keyRef))
 
-	return i.kref, nil
+	return keyRef, nil
 }
 
 // getCertRef gets the SecCertificateRef for this identity's certificate.
 func (i *macIdentity) getCertRef() (C.SecCertificateRef, error) {
-	if i.cref != nilSecCertificateRef {
-		return i.cref, nil
+	if cref := C.SecCertificateRef(i.cref.Load()); cref != nilSecCertificateRef {
+		return cref, nil
 	}
 
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	if i.cref != nilSecCertificateRef {
-		return i.cref, nil
+	if cref := C.SecCertificateRef(i.cref.Load()); cref != nilSecCertificateRef {
+		return cref, nil
 	}
 
 	var certRef C.SecCertificateRef
@@ -428,9 +427,9 @@ func (i *macIdentity) getCertRef() (C.SecCertificateRef, error) {
 		return nilSecCertificateRef, err
 	}
 
-	i.cref = certRef
+	i.cref.Store(uintptr(certRef))
 
-	return i.cref, nil
+	return certRef, nil
 }
 
 // exportCertRef gets a *x509.Certificate for the given SecCertificateRef.

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -389,6 +389,10 @@ func (i *macIdentity) getAlgo(hash crypto.Hash, opts crypto.SignerOpts) (algo C.
 
 // getKeyRef gets the SecKeyRef for this identity's pricate key.
 func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
+	if i.kref != nilSecKeyRef {
+		return i.kref, nil
+	}
+
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -408,6 +412,10 @@ func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
 
 // getCertRef gets the SecCertificateRef for this identity's certificate.
 func (i *macIdentity) getCertRef() (C.SecCertificateRef, error) {
+	if i.cref != nilSecCertificateRef {
+		return i.cref, nil
+	}
+
 	i.mu.Lock()
 	defer i.mu.Unlock()
 

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -158,6 +158,7 @@ func (i *macIdentity) CertificateChain() ([]*x509.Certificate, error) {
 	}
 
 	policy := C.SecPolicyCreateSSL(0, nilCFStringRef)
+	defer C.CFRelease(C.CFTypeRef(policy))
 
 	var trustRef C.SecTrustRef
 	if err := osStatusError(C.SecTrustCreateWithCertificates(C.CFTypeRef(certRef), C.CFTypeRef(policy), &trustRef)); err != nil {
@@ -170,6 +171,9 @@ func (i *macIdentity) CertificateChain() ([]*x509.Certificate, error) {
 	// us if the chain isn't trusted by the underlying system.
 	var cerr C.CFErrorRef
 	C.SecTrustEvaluateWithError(trustRef, &cerr)
+	if cerr != nilCFErrorRef {
+		C.CFRelease(C.CFTypeRef(cerr))
+	}
 
 	var (
 		nchain = C.SecTrustGetCertificateCount(trustRef)

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sync"
 	"unsafe"
 )
 
@@ -117,6 +118,7 @@ func (s macStore) Close() {}
 
 // macIdentity implements the Identity interface.
 type macIdentity struct {
+	mu    sync.Mutex
 	ref   C.SecIdentityRef
 	kref  C.SecKeyRef
 	cref  C.SecCertificateRef
@@ -241,6 +243,9 @@ func (i *macIdentity) Delete() error {
 
 // Close implements the Identity interface.
 func (i *macIdentity) Close() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	if i.ref != nilSecIdentityRef {
 		C.CFRelease(C.CFTypeRef(i.ref))
 		i.ref = nilSecIdentityRef
@@ -384,6 +389,9 @@ func (i *macIdentity) getAlgo(hash crypto.Hash, opts crypto.SignerOpts) (algo C.
 
 // getKeyRef gets the SecKeyRef for this identity's pricate key.
 func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	if i.kref != nilSecKeyRef {
 		return i.kref, nil
 	}
@@ -400,6 +408,9 @@ func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
 
 // getCertRef gets the SecCertificateRef for this identity's certificate.
 func (i *macIdentity) getCertRef() (C.SecCertificateRef, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	if i.cref != nilSecCertificateRef {
 		return i.cref, nil
 	}

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -387,7 +387,7 @@ func (i *macIdentity) getAlgo(hash crypto.Hash, opts crypto.SignerOpts) (algo C.
 	return
 }
 
-// getKeyRef gets the SecKeyRef for this identity's pricate key.
+// getKeyRef gets the SecKeyRef for this identity's private key.
 func (i *macIdentity) getKeyRef() (C.SecKeyRef, error) {
 	if i.kref != nilSecKeyRef {
 		return i.kref, nil

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -20,7 +20,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 )
 
-// Policy wraps a OPA policy and supports reloading at runtime.
+// Policy wraps an OPA policy and supports reloading at runtime.
 type Policy interface {
 	// Reload will reload the policy. Subsequent calls to Evaluate will run
 	// the newly loaded policy, if reloading was successful. If reloading fails,


### PR DESCRIPTION
Identified various bugs using Claude Code:

- Fix CGo memory leaks in CertificateChain: release SecPolicyRef and CFErrorRef that were never freed
- Fix data race in getKeyRef/getCertRef lazy init using double-checked locking
- Use %w for error wrapping in DER parse failures and errors.Is for EOF checks in JCEKS parser
- Fix inaccurate/missing godoc comments