### PR TITLE
Augment PROXY protocol v2 with TLS metadata TLVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,10 +373,13 @@ See [SOCKET-ACTIVATION](docs/SOCKET-ACTIVATION.md) for examples.
 ### PROXY Protocol Support
 
 Ghostunnel in server mode supports signalling of transport connection information
-to the backend using the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
-(v2), just pass the `--proxy-protocol` flag on startup. Note that the backend must
-also support the PROXY protocol and must be configured to use it when setting
-this option.
+to the backend using the [PROXY protocol](https://www.haproxy.org/download/3.1/doc/proxy-protocol.txt)
+(v2), just pass the `--proxy-protocol` flag on startup. Use `--proxy-protocol-mode`
+to also include TLS metadata and/or client certificate details. Note that the
+backend must support the PROXY protocol and must be configured to use it when
+setting this option.
+
+See [PROXY-PROTOCOL](docs/PROXY-PROTOCOL.md) for details on modes and TLV extensions.
 
 ### Landlock Support
 

--- a/docs/ACCESS-FLAGS.md
+++ b/docs/ACCESS-FLAGS.md
@@ -67,7 +67,7 @@ from any client. This means that anyone will be able to establish a connection
 to the Ghostunnel server. This flag is mutually exclusive with other access
 control flags.
 
-### Passing client identity to backends
+### Passing Client Identity to Backends
 
 Ghostunnel verifies client certificates before forwarding connections, but
 backends may also need to know the client's identity for their own access

--- a/docs/ACCESS-FLAGS.md
+++ b/docs/ACCESS-FLAGS.md
@@ -67,6 +67,14 @@ from any client. This means that anyone will be able to establish a connection
 to the Ghostunnel server. This flag is mutually exclusive with other access
 control flags.
 
+### Passing client identity to backends
+
+Ghostunnel verifies client certificates before forwarding connections, but
+backends may also need to know the client's identity for their own access
+control, logging, or auditing. Use `--proxy-protocol-mode=tls-full` to forward
+the client certificate (CN, full DER-encoded cert) to the backend via
+[PROXY protocol v2]({{< ref "PROXY-PROTOCOL.md" >}}) TLV extensions.
+
 ## Client mode
 
 Ghostunnel in client mode offers various flags that can be used to augment and

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -109,10 +109,13 @@ See [Socket Activation]({{< ref "SOCKET-ACTIVATION.md" >}}) for `systemd:NAME` a
 
 ### Proxying
 
+See [PROXY Protocol]({{< ref "PROXY-PROTOCOL.md" >}}) for details on modes and TLV extensions.
+
 | Flag | Description |
 |------|-------------|
 | `--target-status URL` | Address to target for status checking downstream healthchecks. Defaults to TCP healthcheck if not passed. |
-| `--proxy-protocol` | Enable PROXY protocol v2 to signal connection info to backend. |
+| `--proxy-protocol` | Enable PROXY protocol v2 with connection info only (equivalent to `--proxy-protocol-mode=conn`). |
+| `--proxy-protocol-mode MODE` | PROXY protocol v2 mode: `conn`, `tls`, or `tls-full`. Mutually exclusive with `--proxy-protocol`. |
 | `--unsafe-target` | Do not limit target to localhost, `127.0.0.1`, `[::1]`, or UNIX sockets. See [Security]({{< ref "SECURITY.md" >}}). |
 
 ### Access Control

--- a/docs/PROXY-PROTOCOL.md
+++ b/docs/PROXY-PROTOCOL.md
@@ -12,7 +12,7 @@ forwarded connection carrying the original client metadata. Backends can then
 do logging, access control, or auditing based on client identity without
 needing their own TLS stack.
 
-### Enabling
+## Enabling
 
 See [Command-Line Flags]({{< ref "FLAGS.md" >}}) for the full flag reference.
 
@@ -52,20 +52,20 @@ pass both.
 The backend will receive a PROXY protocol v2 binary header on each new
 connection, followed by the normal application data stream.
 
-### What Ghostunnel sends
+## What Ghostunnel Sends
 
 Ghostunnel sends a **version 2** (binary format) header with the `PROXY`
 command. The address family (IPv4 or IPv6) is detected from the incoming
 connection.
 
-#### Address fields (all modes)
+### Address Fields (All Modes)
 
 | Field | Value |
 |-------|-------|
 | Source address/port | Original client IP and port |
 | Destination address/port | Ghostunnel's listen IP and port |
 
-#### TLV extensions (`tls` and `tls-full` modes)
+### TLV Extensions (`tls` and `tls-full` Modes)
 
 When using `--proxy-protocol-mode=tls` or `--proxy-protocol-mode=tls-full`,
 Ghostunnel includes TLV (Type-Length-Value) extensions with TLS connection
@@ -77,7 +77,7 @@ metadata:
 | `PP2_TYPE_AUTHORITY` | `0x02` | SNI hostname the client requested (if set) |
 | `PP2_TYPE_ALPN` | `0x01` | Negotiated ALPN protocol, e.g. `h2` (if set) |
 
-#### SSL sub-TLVs
+### SSL Sub-TLVs
 
 The `PP2_TYPE_SSL` TLV contains a 5-byte sub-header followed by nested
 sub-TLVs:
@@ -112,7 +112,7 @@ HAProxy spec but is supported by the
 [go-proxyproto](https://github.com/pires/go-proxyproto) library and others.
 The spec requires receivers to ignore unknown TLV types, so this is safe.
 
-### Backend requirements
+## Backend Requirements
 
 Your backend must be configured to expect PROXY protocol headers. It needs to
 parse the binary header before reading application data. Most servers and
@@ -126,7 +126,7 @@ frameworks support this:
 Backends that aren't expecting PROXY protocol will see the binary header as
 garbage at the start of the stream and will reject the connection.
 
-### References
+## References
 
 - [PROXY protocol specification](https://www.haproxy.org/download/3.1/doc/proxy-protocol.txt) (HAProxy, covers v1 and v2; see section 2.2 for the TLV type registry)
 - [go-proxyproto](https://github.com/pires/go-proxyproto) (Go library used by Ghostunnel)

--- a/docs/PROXY-PROTOCOL.md
+++ b/docs/PROXY-PROTOCOL.md
@@ -1,0 +1,132 @@
+---
+title: PROXY Protocol
+description: Pass original client connection metadata (IP, TLS version, client certificate) through to plaintext backends using HAProxy's PROXY protocol v2.
+weight: 55
+---
+
+When Ghostunnel terminates TLS, the backend only sees a plaintext connection
+from Ghostunnel itself. It has no idea who the original client was, what TLS
+version was negotiated, or whether a client certificate was presented. The PROXY
+protocol fixes this: Ghostunnel prepends a small binary header to each
+forwarded connection carrying the original client metadata. Backends can then
+do logging, access control, or auditing based on client identity without
+needing their own TLS stack.
+
+### Enabling
+
+See [Command-Line Flags]({{< ref "FLAGS.md" >}}) for the full flag reference.
+
+Pass `--proxy-protocol` in server mode to enable PROXY protocol v2 with
+connection info (source/destination IP and port):
+
+```bash
+ghostunnel server \
+  --listen=:8443 \
+  --target=localhost:8080 \
+  --keystore=server.p12 \
+  --cacert=ca.crt \
+  --allow-ou=my-service \
+  --proxy-protocol
+```
+
+To also include TLS metadata and/or client certificate details, use the
+`--proxy-protocol-mode` flag:
+
+| Mode | What is sent |
+|------|-------------|
+| `conn` | Connection info only (src/dst IP+port). Same as bare `--proxy-protocol`. |
+| `tls` | Connection info + TLS metadata (version, ALPN, SNI). No client cert details. |
+| `tls-full` | Connection info + TLS metadata + full client certificate details. |
+
+```bash
+# TLS metadata without client cert:
+ghostunnel server ... --proxy-protocol-mode=tls
+
+# Everything, including client cert:
+ghostunnel server ... --proxy-protocol-mode=tls-full
+```
+
+Using `--proxy-protocol-mode` implies `--proxy-protocol`; you do not need to
+pass both.
+
+The backend will receive a PROXY protocol v2 binary header on each new
+connection, followed by the normal application data stream.
+
+### What Ghostunnel sends
+
+Ghostunnel sends a **version 2** (binary format) header with the `PROXY`
+command. The address family (IPv4 or IPv6) is detected from the incoming
+connection.
+
+#### Address fields (all modes)
+
+| Field | Value |
+|-------|-------|
+| Source address/port | Original client IP and port |
+| Destination address/port | Ghostunnel's listen IP and port |
+
+#### TLV extensions (`tls` and `tls-full` modes)
+
+When using `--proxy-protocol-mode=tls` or `--proxy-protocol-mode=tls-full`,
+Ghostunnel includes TLV (Type-Length-Value) extensions with TLS connection
+metadata:
+
+| TLV | Type | Description |
+|-----|------|-------------|
+| `PP2_TYPE_SSL` | `0x20` | Container for SSL/TLS metadata (see below) |
+| `PP2_TYPE_AUTHORITY` | `0x02` | SNI hostname the client requested (if set) |
+| `PP2_TYPE_ALPN` | `0x01` | Negotiated ALPN protocol, e.g. `h2` (if set) |
+
+#### SSL sub-TLVs
+
+The `PP2_TYPE_SSL` TLV contains a 5-byte sub-header followed by nested
+sub-TLVs:
+
+**Sub-header:**
+
+| Field | Size | Description |
+|-------|------|-------------|
+| Client flags | 1 byte | Bitfield: `0x01` = SSL used, `0x02` = client cert on connection, `0x04` = client cert on session |
+| Verify result | 4 bytes | `0` = certificate verified successfully |
+
+**Nested sub-TLVs (always present in `tls` and `tls-full` modes):**
+
+| Sub-TLV | Type | Example value |
+|---------|------|---------------|
+| `PP2_SUBTYPE_SSL_VERSION` | `0x21` | `TLS 1.3` |
+
+**Nested sub-TLVs (`tls-full` mode only, when a client certificate was provided):**
+
+| Sub-TLV | Type | Description |
+|---------|------|-------------|
+| `PP2_SUBTYPE_SSL_CN` | `0x22` | Client certificate Common Name |
+| `PP2_SUBTYPE_SSL_CLIENT_CERT` | `0x28` | Full client certificate in DER (ASN.1) encoding |
+
+The `tls-full` mode is useful when backends need to perform their own access
+control or auditing based on client certificate identity. See [Access Control
+Flags]({{< ref "ACCESS-FLAGS.md" >}}) for how Ghostunnel itself verifies
+client certificates before forwarding.
+
+Note: `PP2_SUBTYPE_SSL_CLIENT_CERT` (`0x28`) is not part of the original
+HAProxy spec but is supported by the
+[go-proxyproto](https://github.com/pires/go-proxyproto) library and others.
+The spec requires receivers to ignore unknown TLV types, so this is safe.
+
+### Backend requirements
+
+Your backend must be configured to expect PROXY protocol headers. It needs to
+parse the binary header before reading application data. Most servers and
+frameworks support this:
+
+- **nginx**: `proxy_protocol` parameter on `listen` directive
+- **Apache**: `mod_remoteip` with `RemoteIPProxyProtocol`
+- **HAProxy**: `accept-proxy` on `bind` lines
+- **Custom apps**: use a PROXY protocol parsing library for your language
+
+Backends that aren't expecting PROXY protocol will see the binary header as
+garbage at the start of the stream and will reject the connection.
+
+### References
+
+- [PROXY protocol specification](https://www.haproxy.org/download/3.1/doc/proxy-protocol.txt) (HAProxy, covers v1 and v2; see section 2.2 for the TLV type registry)
+- [go-proxyproto](https://github.com/pires/go-proxyproto) (Go library used by Ghostunnel)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -134,4 +134,5 @@ forwarded the plaintext request to the backend.
 - [Access Control Flags]({{< ref "ACCESS-FLAGS.md" >}}): control who can connect (CN, OU, DNS/URI SAN, OPA)
 - [ACME Support]({{< ref "ACME.md" >}}): automatic certificates from Let's Encrypt
 - [Metrics & Profiling]({{< ref "METRICS.md" >}}): status port, Prometheus metrics, pprof
+- [PROXY Protocol]({{< ref "PROXY-PROTOCOL.md" >}}): pass client connection metadata to backends
 - [Socket Activation]({{< ref "SOCKET-ACTIVATION.md" >}}) and [Systemd Watchdog]({{< ref "WATCHDOG.md" >}}): run Ghostunnel as a service

--- a/main.go
+++ b/main.go
@@ -77,7 +77,8 @@ var (
 	serverListenAddress       = serverCommand.Flag("listen", "Address and port to listen on (can be HOST:PORT, unix:PATH, systemd:NAME or launchd:NAME).").PlaceHolder("ADDR").Required().String()
 	serverForwardAddress      = serverCommand.Flag("target", "Address to forward connections to (can be HOST:PORT or unix:PATH).").PlaceHolder("ADDR").Required().String()
 	serverStatusTargetAddress = serverCommand.Flag("target-status", "Address to target for status checking downstream healthchecks. Defaults to a TCP healthcheck if this flag is not passed.").Default("").String()
-	serverProxyProtocol       = serverCommand.Flag("proxy-protocol", "Enable PROXY protocol v2 to signal connection info to backend").Bool()
+	serverProxyProtocol       = serverCommand.Flag("proxy-protocol", "Enable PROXY protocol v2 (connection info only, equivalent to --proxy-protocol-mode=conn).").Bool()
+	serverProxyProtocolMode   = serverCommand.Flag("proxy-protocol-mode", "PROXY protocol v2 mode: conn (connection info only), tls (add TLS version/ALPN/SNI metadata), tls-full (add TLS metadata and client certificate). Mutually exclusive with --proxy-protocol.").Enum("conn", "tls", "tls-full")
 	serverUnsafeTarget        = serverCommand.Flag("unsafe-target", "If set, does not limit target to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
 	serverAllowAll            = serverCommand.Flag("allow-all", "Allow all clients, do not check client cert subject.").Bool()
 	serverAllowedCNs          = serverCommand.Flag("allow-cn", "Allow clients with given common name (can be repeated).").PlaceHolder("CN").Strings()
@@ -395,7 +396,17 @@ func serverValidateFlags() error {
 	if err := validateServerOPA(hasAccessFlags, hasOPAFlags); err != nil {
 		return err
 	}
+	if err := validateServerProxyProtocol(); err != nil {
+		return err
+	}
 	return validateCipherSuites()
+}
+
+func validateServerProxyProtocol() error {
+	if *serverProxyProtocol && *serverProxyProtocolMode != "" {
+		return errors.New("--proxy-protocol and --proxy-protocol-mode are mutually exclusive")
+	}
+	return nil
 }
 
 func validateClientCredentials() error {
@@ -431,6 +442,25 @@ func clientValidateFlags() error {
 		return err
 	}
 	return validateCipherSuites()
+}
+
+// serverProxyProtoMode computes the ProxyProtocolMode from the
+// --proxy-protocol and --proxy-protocol-mode flags.
+func serverProxyProtoMode() proxy.ProxyProtocolMode {
+	if *serverProxyProtocolMode != "" {
+		switch *serverProxyProtocolMode {
+		case "tls":
+			return proxy.ProxyProtocolTLS
+		case "tls-full":
+			return proxy.ProxyProtocolTLSFull
+		default:
+			return proxy.ProxyProtocolConn
+		}
+	}
+	if *serverProxyProtocol {
+		return proxy.ProxyProtocolConn
+	}
+	return proxy.ProxyProtocolOff
 }
 
 func main() {
@@ -679,7 +709,7 @@ func serverListen(env *Environment) error {
 		env.dial,
 		logger,
 		proxyLoggerFlags(*quiet),
-		*serverProxyProtocol,
+		serverProxyProtoMode(),
 	)
 
 	if *statusAddress != "" {
@@ -724,7 +754,7 @@ func clientListen(env *Environment) error {
 		env.dial,
 		logger,
 		proxyLoggerFlags(*quiet),
-		false,
+		proxy.ProxyProtocolOff,
 	)
 
 	if *statusAddress != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -458,6 +458,47 @@ func TestProxyLoggingFlags(t *testing.T) {
 	assert.Equal(t, proxyLoggerFlags([]string{"conns", "conn-errs"}), proxy.LogHandshakeErrors)
 }
 
+func TestServerProxyProtoMode(t *testing.T) {
+	// Save and restore globals
+	origProto := *serverProxyProtocol
+	origMode := *serverProxyProtocolMode
+	defer func() {
+		*serverProxyProtocol = origProto
+		*serverProxyProtocolMode = origMode
+	}()
+
+	// Neither flag set → Off
+	*serverProxyProtocol = false
+	*serverProxyProtocolMode = ""
+	assert.Equal(t, proxy.ProxyProtocolOff, serverProxyProtoMode())
+
+	// Only --proxy-protocol → Conn
+	*serverProxyProtocol = true
+	*serverProxyProtocolMode = ""
+	assert.Equal(t, proxy.ProxyProtocolConn, serverProxyProtoMode())
+
+	// Only --proxy-protocol-mode=tls → TLS
+	*serverProxyProtocol = false
+	*serverProxyProtocolMode = "tls"
+	assert.Equal(t, proxy.ProxyProtocolTLS, serverProxyProtoMode())
+
+	// Only --proxy-protocol-mode=tls-full → TLSFull
+	*serverProxyProtocol = false
+	*serverProxyProtocolMode = "tls-full"
+	assert.Equal(t, proxy.ProxyProtocolTLSFull, serverProxyProtoMode())
+
+	// Only --proxy-protocol-mode=conn → Conn
+	*serverProxyProtocol = false
+	*serverProxyProtocolMode = "conn"
+	assert.Equal(t, proxy.ProxyProtocolConn, serverProxyProtoMode())
+
+	// Both set: validation rejects this combination
+	*serverProxyProtocol = true
+	*serverProxyProtocolMode = "tls-full"
+	err := validateServerProxyProtocol()
+	assert.ErrorContains(t, err, "mutually exclusive")
+}
+
 // failingTLSConfigSource is a mock TLSConfigSource that always returns errors
 type failingTLSConfigSource struct{}
 

--- a/main_test.go
+++ b/main_test.go
@@ -347,6 +347,24 @@ func TestServerFlagValidation(t *testing.T) {
 	*serverAllowQuery = ""
 	*serverAllowedURIs = nil
 	*keystorePath = ""
+
+	// Test: --proxy-protocol and --proxy-protocol-mode are mutually exclusive
+	*keystorePath = "file"
+	*serverAllowAll = true
+	*serverProxyProtocol = true
+	*serverProxyProtocolMode = "tls"
+	err = serverValidateFlags()
+	assert.NotNil(t, err, "--proxy-protocol and --proxy-protocol-mode are mutually exclusive")
+
+	// Test: --proxy-protocol-mode alone is valid
+	*serverProxyProtocol = false
+	*serverProxyProtocolMode = "tls"
+	err = serverValidateFlags()
+	assert.Nil(t, err, "--proxy-protocol-mode alone should be valid")
+	*serverProxyProtocol = false
+	*serverProxyProtocolMode = ""
+	*serverAllowAll = false
+	*keystorePath = ""
 }
 
 func TestClientFlagValidation(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -19,7 +19,9 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -29,6 +31,20 @@ import (
 	proxyproto "github.com/pires/go-proxyproto"
 	metrics "github.com/rcrowley/go-metrics"
 	sem "golang.org/x/sync/semaphore"
+)
+
+// ProxyProtocolMode controls PROXY protocol v2 header generation.
+type ProxyProtocolMode int
+
+const (
+	// ProxyProtocolOff disables PROXY protocol headers.
+	ProxyProtocolOff ProxyProtocolMode = iota
+	// ProxyProtocolConn sends connection info (src/dst IP+port) only, no TLVs.
+	ProxyProtocolConn
+	// ProxyProtocolTLS sends connection info + TLS metadata (version, ALPN, SNI) without client cert details.
+	ProxyProtocolTLS
+	// ProxyProtocolTLSFull sends connection info + all TLVs including client certificate.
+	ProxyProtocolTLSFull
 )
 
 var (
@@ -79,7 +95,7 @@ type Proxy struct {
 	loggerFlags int
 	// Enable HAproxy's PROXY protocol
 	// see: https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
-	proxyProtocol bool
+	proxyProtocol ProxyProtocolMode
 	// Internal wait group to keep track of outstanding handlers.
 	handlers *sync.WaitGroup
 	// Semaphore to limit the max. number of connections.
@@ -91,14 +107,128 @@ type Proxy struct {
 	pool sync.Pool
 }
 
-func proxyProtoHeader(c net.Conn) *proxyproto.Header {
-	return &proxyproto.Header{
+// PROXY protocol v2 client flag constants (from spec section 2.2.5).
+const (
+	pp2ClientSSL      = 0x01
+	pp2ClientCertConn = 0x02
+	pp2ClientCertSess = 0x04
+)
+
+func transportProtocol(c net.Conn) proxyproto.AddressFamilyAndProtocol {
+	if addr, ok := c.RemoteAddr().(*net.TCPAddr); ok {
+		if addr.IP.To4() != nil {
+			return proxyproto.TCPv4
+		}
+		return proxyproto.TCPv6
+	}
+	return proxyproto.TCPv4
+}
+
+func proxyProtoHeader(c net.Conn, tlsState *tls.ConnectionState, mode ProxyProtocolMode, logger Logger) *proxyproto.Header {
+	h := &proxyproto.Header{
 		Version:           2,
 		Command:           proxyproto.PROXY,
-		TransportProtocol: proxyproto.TCPv4,
+		TransportProtocol: transportProtocol(c),
 		SourceAddr:        c.RemoteAddr(),
 		DestinationAddr:   c.LocalAddr(),
 	}
+
+	if tlsState != nil && mode >= ProxyProtocolTLS {
+		tlvs, err := buildTLVs(tlsState, mode)
+		if err != nil {
+			logger.Printf("proxy: failed to build PROXY protocol TLVs: %s", err)
+		} else if len(tlvs) > 0 {
+			if err := h.SetTLVs(tlvs); err != nil {
+				logger.Printf("proxy: failed to set PROXY protocol TLVs: %s", err)
+			}
+		}
+	}
+
+	return h
+}
+
+// buildTLVs constructs the top-level TLV list from TLS connection state.
+func buildTLVs(state *tls.ConnectionState, mode ProxyProtocolMode) ([]proxyproto.TLV, error) {
+	var tlvs []proxyproto.TLV
+
+	// PP2_TYPE_ALPN
+	if state.NegotiatedProtocol != "" {
+		tlvs = append(tlvs, proxyproto.TLV{
+			Type:  proxyproto.PP2_TYPE_ALPN,
+			Value: []byte(state.NegotiatedProtocol),
+		})
+	}
+
+	// PP2_TYPE_AUTHORITY (SNI)
+	if state.ServerName != "" {
+		tlvs = append(tlvs, proxyproto.TLV{
+			Type:  proxyproto.PP2_TYPE_AUTHORITY,
+			Value: []byte(state.ServerName),
+		})
+	}
+
+	// PP2_TYPE_SSL with nested sub-TLVs
+	sslTLV, err := buildSSLTLV(state, mode)
+	if err != nil {
+		return nil, err
+	}
+	tlvs = append(tlvs, sslTLV)
+
+	return tlvs, nil
+}
+
+// buildSSLTLV constructs the PP2_TYPE_SSL TLV with its 5-byte sub-header
+// and nested sub-TLVs containing TLS connection metadata.
+func buildSSLTLV(state *tls.ConnectionState, mode ProxyProtocolMode) (proxyproto.TLV, error) {
+	var subTLVs []proxyproto.TLV
+
+	// Always include TLS version
+	subTLVs = append(subTLVs, proxyproto.TLV{
+		Type:  proxyproto.PP2_SUBTYPE_SSL_VERSION,
+		Value: []byte(tls.VersionName(state.Version)),
+	})
+
+	// Client certificate fields (only in TLSFull mode and if a cert was presented)
+	if mode == ProxyProtocolTLSFull && len(state.PeerCertificates) > 0 {
+		cert := state.PeerCertificates[0]
+
+		if cert.Subject.CommonName != "" {
+			subTLVs = append(subTLVs, proxyproto.TLV{
+				Type:  proxyproto.PP2_SUBTYPE_SSL_CN,
+				Value: []byte(cert.Subject.CommonName),
+			})
+		}
+
+		// Full DER-encoded client certificate (extension, not in HAProxy spec)
+		subTLVs = append(subTLVs, proxyproto.TLV{
+			Type:  proxyproto.PP2_SUBTYPE_SSL_CLIENT_CERT,
+			Value: cert.Raw,
+		})
+	}
+
+	// Build 5-byte sub-header: 1 byte flags + 4 bytes verify result
+	var flags byte = pp2ClientSSL
+	if mode == ProxyProtocolTLSFull && len(state.PeerCertificates) > 0 {
+		// Set both flags: Ghostunnel doesn't distinguish connection-level vs
+		// session-level (resumed) cert presentation — the cert was verified
+		// on this connection either way.
+		flags |= pp2ClientCertConn | pp2ClientCertSess
+	}
+	var header [5]byte
+	header[0] = flags
+	binary.BigEndian.PutUint32(header[1:5], 0) // verify=0, cert already verified by ghostunnel
+
+	// Encode sub-TLVs and append after the 5-byte header
+	subTLVBytes, err := proxyproto.JoinTLVs(subTLVs)
+	if err != nil {
+		return proxyproto.TLV{}, fmt.Errorf("encoding SSL sub-TLVs: %w", err)
+	}
+
+	value := make([]byte, len(header)+len(subTLVBytes))
+	copy(value, header[:])
+	copy(value[len(header):], subTLVBytes)
+
+	return proxyproto.TLV{Type: proxyproto.PP2_TYPE_SSL, Value: value}, nil
 }
 
 // New creates a new proxy.
@@ -109,7 +239,7 @@ func New(
 	dial DialFunc,
 	logger Logger,
 	loggerFlags int,
-	proxyProtocol bool) *Proxy {
+	proxyProtocol ProxyProtocolMode) *Proxy {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -219,8 +349,13 @@ func (p *Proxy) Accept() {
 				return
 			}
 
-			if p.proxyProtocol {
-				h := proxyProtoHeader(conn)
+			if p.proxyProtocol != ProxyProtocolOff {
+				var tlsState *tls.ConnectionState
+				if tlsConn, ok := conn.(*tls.Conn); ok {
+					state := tlsConn.ConnectionState()
+					tlsState = &state
+				}
+				h := proxyProtoHeader(conn, tlsState, p.proxyProtocol, p.Logger)
 				_, err = h.WriteTo(backend)
 				if err != nil {
 					p.logConditional(LogConnectionErrors, "error writing proxy header: %s", err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -20,9 +20,17 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"os"
 	"testing"
@@ -45,11 +53,11 @@ func (m *failingListener) Close() error              { return nil }
 func (m *failingListener) Addr() net.Addr            { return nil }
 
 func proxyForTest(listener net.Listener, dialer DialFunc) *Proxy {
-	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, false)
+	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolOff)
 }
 
 func proxyForTestWithProxyProtocol(listener net.Listener, dialer DialFunc) *Proxy {
-	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, true)
+	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolConn)
 }
 
 func TestAbortedConnection(t *testing.T) {
@@ -534,7 +542,7 @@ func TestForceHandshakeNonTLSConn(t *testing.T) {
 
 func TestLogConnectionMessageDisabled(t *testing.T) {
 	// Test with LogConnections disabled
-	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, &testLogger{}, 0, false)
+	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, &testLogger{}, 0, ProxyProtocolOff)
 
 	// Create pipe connections
 	src, dst := net.Pipe()
@@ -552,7 +560,7 @@ func TestLogConditional(t *testing.T) {
 	}}
 
 	// Test with flag enabled
-	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, logger, LogConnectionErrors, false)
+	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, logger, LogConnectionErrors, ProxyProtocolOff)
 	p.logConditional(LogConnectionErrors, "test message")
 	assert.True(t, logged, "should log when flag is enabled")
 
@@ -568,4 +576,363 @@ type callbackLogger struct {
 
 func (c *callbackLogger) Printf(format string, v ...any) {
 	c.callback(format, v...)
+}
+
+func TestTransportProtocol(t *testing.T) {
+	t.Run("IPv4", func(t *testing.T) {
+		ln, err := net.Listen("tcp4", "127.0.0.1:0")
+		assert.Nil(t, err)
+		defer ln.Close()
+
+		go func() {
+			c, _ := ln.Accept()
+			if c != nil {
+				c.Close()
+			}
+		}()
+
+		conn, err := net.Dial("tcp4", ln.Addr().String())
+		assert.Nil(t, err)
+		defer conn.Close()
+
+		assert.Equal(t, proxyproto.TCPv4, transportProtocol(conn))
+	})
+
+	t.Run("IPv6", func(t *testing.T) {
+		ln, err := net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			t.Skip("IPv6 not available")
+		}
+		defer ln.Close()
+
+		go func() {
+			c, _ := ln.Accept()
+			if c != nil {
+				c.Close()
+			}
+		}()
+
+		conn, err := net.Dial("tcp6", ln.Addr().String())
+		assert.Nil(t, err)
+		defer conn.Close()
+
+		assert.Equal(t, proxyproto.TCPv6, transportProtocol(conn))
+	})
+
+	t.Run("non-TCP fallback", func(t *testing.T) {
+		conn := &mockConn{} // RemoteAddr returns *net.IPAddr, not *net.TCPAddr
+		assert.Equal(t, proxyproto.TCPv4, transportProtocol(conn))
+	})
+}
+
+// selfSignedCert creates a self-signed certificate for testing.
+func selfSignedCert(t *testing.T) (tls.Certificate, *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.Nil(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:         "test-cn",
+			OrganizationalUnit: []string{"test-ou"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	assert.Nil(t, err)
+
+	parsedCert, err := x509.ParseCertificate(certDER)
+	assert.Nil(t, err)
+
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}, parsedCert
+}
+
+func TestBuildSSLTLV(t *testing.T) {
+	t.Run("without client cert", func(t *testing.T) {
+		state := &tls.ConnectionState{
+			Version:     tls.VersionTLS13,
+			CipherSuite: tls.TLS_AES_128_GCM_SHA256,
+		}
+
+		tlv, err := buildSSLTLV(state, ProxyProtocolTLSFull)
+		assert.Nil(t, err)
+		assert.Equal(t, proxyproto.PP2_TYPE_SSL, tlv.Type)
+
+		// Parse 5-byte sub-header
+		assert.True(t, len(tlv.Value) >= 5, "SSL TLV value must be at least 5 bytes")
+		flags := tlv.Value[0]
+		verify := binary.BigEndian.Uint32(tlv.Value[1:5])
+
+		assert.Equal(t, byte(pp2ClientSSL), flags, "should only have PP2_CLIENT_SSL flag")
+		assert.Equal(t, uint32(0), verify, "verify result should be 0")
+
+		// Parse nested sub-TLVs
+		subTLVs, err := proxyproto.SplitTLVs(tlv.Value[5:])
+		assert.Nil(t, err)
+
+		// Should have VERSION only, not CN/CLIENT_CERT
+		typeSet := make(map[proxyproto.PP2Type][]byte)
+		for _, st := range subTLVs {
+			typeSet[st.Type] = st.Value
+		}
+
+		assert.Contains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_VERSION)
+		assert.Equal(t, "TLS 1.3", string(typeSet[proxyproto.PP2_SUBTYPE_SSL_VERSION]))
+		assert.NotContains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_CN)
+		assert.NotContains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_CLIENT_CERT)
+	})
+
+	t.Run("with client cert", func(t *testing.T) {
+		_, parsedCert := selfSignedCert(t)
+
+		state := &tls.ConnectionState{
+			Version:          tls.VersionTLS13,
+			CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+			PeerCertificates: []*x509.Certificate{parsedCert},
+		}
+
+		tlv, err := buildSSLTLV(state, ProxyProtocolTLSFull)
+		assert.Nil(t, err)
+
+		// Parse sub-header
+		flags := tlv.Value[0]
+		assert.Equal(t, byte(pp2ClientSSL|pp2ClientCertConn|pp2ClientCertSess), flags)
+
+		// Parse nested sub-TLVs
+		subTLVs, err := proxyproto.SplitTLVs(tlv.Value[5:])
+		assert.Nil(t, err)
+
+		typeSet := make(map[proxyproto.PP2Type][]byte)
+		for _, st := range subTLVs {
+			typeSet[st.Type] = st.Value
+		}
+
+		assert.Equal(t, "test-cn", string(typeSet[proxyproto.PP2_SUBTYPE_SSL_CN]))
+		assert.NotContains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_KEY_ALG)
+		assert.Equal(t, parsedCert.Raw, typeSet[proxyproto.PP2_SUBTYPE_SSL_CLIENT_CERT])
+	})
+
+	t.Run("TLS mode excludes client cert", func(t *testing.T) {
+		_, parsedCert := selfSignedCert(t)
+
+		state := &tls.ConnectionState{
+			Version:          tls.VersionTLS13,
+			CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+			PeerCertificates: []*x509.Certificate{parsedCert},
+		}
+
+		tlv, err := buildSSLTLV(state, ProxyProtocolTLS)
+		assert.Nil(t, err)
+
+		// Parse sub-header: should only have PP2_CLIENT_SSL (no cert flags)
+		flags := tlv.Value[0]
+		assert.Equal(t, byte(pp2ClientSSL), flags, "TLS mode should not set cert flags")
+
+		// Parse nested sub-TLVs: should have version but no cert details
+		subTLVs, err := proxyproto.SplitTLVs(tlv.Value[5:])
+		assert.Nil(t, err)
+
+		typeSet := make(map[proxyproto.PP2Type][]byte)
+		for _, st := range subTLVs {
+			typeSet[st.Type] = st.Value
+		}
+
+		assert.Contains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_VERSION)
+		assert.NotContains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_CN)
+		assert.NotContains(t, typeSet, proxyproto.PP2_SUBTYPE_SSL_CLIENT_CERT)
+	})
+}
+
+func TestBuildTLVs(t *testing.T) {
+	t.Run("with ALPN and SNI", func(t *testing.T) {
+		state := &tls.ConnectionState{
+			Version:            tls.VersionTLS13,
+			CipherSuite:        tls.TLS_AES_128_GCM_SHA256,
+			NegotiatedProtocol: "h2",
+			ServerName:         "example.com",
+		}
+
+		tlvs, err := buildTLVs(state, ProxyProtocolTLSFull)
+		assert.Nil(t, err)
+
+		typeSet := make(map[proxyproto.PP2Type][]byte)
+		for _, tlv := range tlvs {
+			typeSet[tlv.Type] = tlv.Value
+		}
+
+		assert.Equal(t, "h2", string(typeSet[proxyproto.PP2_TYPE_ALPN]))
+		assert.Equal(t, "example.com", string(typeSet[proxyproto.PP2_TYPE_AUTHORITY]))
+		assert.Contains(t, typeSet, proxyproto.PP2_TYPE_SSL)
+	})
+
+	t.Run("without ALPN and SNI", func(t *testing.T) {
+		state := &tls.ConnectionState{
+			Version:     tls.VersionTLS13,
+			CipherSuite: tls.TLS_AES_128_GCM_SHA256,
+		}
+
+		tlvs, err := buildTLVs(state, ProxyProtocolTLSFull)
+		assert.Nil(t, err)
+
+		typeSet := make(map[proxyproto.PP2Type][]byte)
+		for _, tlv := range tlvs {
+			typeSet[tlv.Type] = tlv.Value
+		}
+
+		assert.NotContains(t, typeSet, proxyproto.PP2_TYPE_ALPN)
+		assert.NotContains(t, typeSet, proxyproto.PP2_TYPE_AUTHORITY)
+		assert.Contains(t, typeSet, proxyproto.PP2_TYPE_SSL)
+	})
+
+	t.Run("TLS mode with client cert", func(t *testing.T) {
+		_, parsedCert := selfSignedCert(t)
+
+		state := &tls.ConnectionState{
+			Version:            tls.VersionTLS13,
+			CipherSuite:        tls.TLS_AES_128_GCM_SHA256,
+			NegotiatedProtocol: "h2",
+			ServerName:         "example.com",
+			PeerCertificates:   []*x509.Certificate{parsedCert},
+		}
+
+		tlvs, err := buildTLVs(state, ProxyProtocolTLS)
+		assert.Nil(t, err)
+
+		typeSet := make(map[proxyproto.PP2Type][]byte)
+		for _, tlv := range tlvs {
+			typeSet[tlv.Type] = tlv.Value
+		}
+
+		// ALPN, SNI, SSL should be present
+		assert.Equal(t, "h2", string(typeSet[proxyproto.PP2_TYPE_ALPN]))
+		assert.Equal(t, "example.com", string(typeSet[proxyproto.PP2_TYPE_AUTHORITY]))
+		assert.Contains(t, typeSet, proxyproto.PP2_TYPE_SSL)
+
+		// SSL TLV should have version but no client cert sub-TLVs
+		sslValue := typeSet[proxyproto.PP2_TYPE_SSL]
+		subTLVs, err := proxyproto.SplitTLVs(sslValue[5:])
+		assert.Nil(t, err)
+
+		subTypeSet := make(map[proxyproto.PP2Type]bool)
+		for _, st := range subTLVs {
+			subTypeSet[st.Type] = true
+		}
+		assert.True(t, subTypeSet[proxyproto.PP2_SUBTYPE_SSL_VERSION])
+		assert.False(t, subTypeSet[proxyproto.PP2_SUBTYPE_SSL_CN])
+		assert.False(t, subTypeSet[proxyproto.PP2_SUBTYPE_SSL_CLIENT_CERT])
+	})
+}
+
+func TestProxyProtoHeaderWithTLS(t *testing.T) {
+	_, parsedCert := selfSignedCert(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	defer ln.Close()
+
+	go func() {
+		c, _ := ln.Accept()
+		if c != nil {
+			c.Close()
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	state := &tls.ConnectionState{
+		Version:          tls.VersionTLS13,
+		CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+		ServerName:       "example.com",
+		PeerCertificates: []*x509.Certificate{parsedCert},
+	}
+
+	h := proxyProtoHeader(conn, state, ProxyProtocolTLSFull, &testLogger{})
+	assert.Equal(t, uint8(2), h.Version)
+	assert.Equal(t, proxyproto.PROXY, proxyproto.ProtocolVersionAndCommand(h.Command))
+	assert.Equal(t, proxyproto.TCPv4, proxyproto.AddressFamilyAndProtocol(h.TransportProtocol))
+
+	// Verify TLVs are present
+	tlvs, err := h.TLVs()
+	assert.Nil(t, err)
+	assert.True(t, len(tlvs) > 0, "should have TLVs when TLS state is provided")
+
+	typeSet := make(map[proxyproto.PP2Type]bool)
+	for _, tlv := range tlvs {
+		typeSet[tlv.Type] = true
+	}
+	assert.True(t, typeSet[proxyproto.PP2_TYPE_SSL])
+	assert.True(t, typeSet[proxyproto.PP2_TYPE_AUTHORITY])
+}
+
+func TestProxyProtoHeaderWithoutTLS(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	defer ln.Close()
+
+	go func() {
+		c, _ := ln.Accept()
+		if c != nil {
+			c.Close()
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	h := proxyProtoHeader(conn, nil, ProxyProtocolTLSFull, &testLogger{})
+	assert.Equal(t, uint8(2), h.Version)
+
+	// Verify no TLVs when no TLS state
+	tlvs, err := h.TLVs()
+	assert.Nil(t, err)
+	assert.Empty(t, tlvs, "should have no TLVs when TLS state is nil")
+}
+
+func TestProxyProtoHeaderConnMode(t *testing.T) {
+	_, parsedCert := selfSignedCert(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	defer ln.Close()
+
+	go func() {
+		c, _ := ln.Accept()
+		if c != nil {
+			c.Close()
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	state := &tls.ConnectionState{
+		Version:          tls.VersionTLS13,
+		CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+		ServerName:       "example.com",
+		PeerCertificates: []*x509.Certificate{parsedCert},
+	}
+
+	// Conn mode should send connection info but no TLVs, even with TLS state
+	h := proxyProtoHeader(conn, state, ProxyProtocolConn, &testLogger{})
+	assert.Equal(t, uint8(2), h.Version)
+	assert.Equal(t, proxyproto.PROXY, proxyproto.ProtocolVersionAndCommand(h.Command))
+
+	tlvs, err := h.TLVs()
+	assert.Nil(t, err)
+	assert.Empty(t, tlvs, "conn mode should have no TLVs even with TLS state")
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -902,6 +902,78 @@ func TestProxyProtoHeaderWithoutTLS(t *testing.T) {
 	assert.Empty(t, tlvs, "should have no TLVs when TLS state is nil")
 }
 
+func TestProxyProtocolTLSModeSuccess(t *testing.T) {
+	cert, _ := selfSignedCert(t)
+
+	// TLS listener (incoming)
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	tcpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	incoming := tls.NewListener(tcpLn, tlsCfg)
+
+	// Plain TCP target (backend)
+	target, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", target.Addr().String())
+	}
+
+	p := New(incoming, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolTLS)
+	go p.Accept()
+	defer p.Shutdown()
+
+	// Connect with TLS client
+	src, err := tls.Dial("tcp", incoming.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         "example.com",
+	})
+	assert.Nil(t, err)
+
+	dst, err := target.Accept()
+	assert.Nil(t, err)
+
+	// Read and verify PROXY protocol header on backend
+	header, err := proxyproto.Read(bufio.NewReaderSize(dst, 512))
+	assert.Nil(t, err, "should be able to read proxy protocol header")
+	assert.Equal(t, uint8(2), header.Version)
+	assert.Equal(t, proxyproto.PROXY, proxyproto.ProtocolVersionAndCommand(header.Command))
+	assert.Equal(t, proxyproto.TCPv4, proxyproto.AddressFamilyAndProtocol(header.TransportProtocol))
+
+	// Verify TLVs contain TLS metadata
+	tlvs, err := header.TLVs()
+	assert.Nil(t, err)
+
+	typeSet := make(map[proxyproto.PP2Type]bool)
+	for _, tlv := range tlvs {
+		typeSet[tlv.Type] = true
+	}
+	assert.True(t, typeSet[proxyproto.PP2_TYPE_SSL], "should have SSL TLV")
+	assert.True(t, typeSet[proxyproto.PP2_TYPE_AUTHORITY], "should have Authority (SNI) TLV")
+
+	// Verify data flows through
+	_, _ = src.Write([]byte("A"))
+	received := make([]byte, 1)
+	for {
+		n, err := dst.Read(received)
+		if err != io.EOF {
+			assert.Nil(t, err, "should receive data on target")
+		}
+		if n == 1 {
+			break
+		}
+	}
+	assert.Equal(t, []byte("A"), received)
+
+	p.Shutdown()
+	dst.Close()
+	src.Close()
+	p.Wait()
+}
+
 func TestProxyProtoHeaderConnMode(t *testing.T) {
 	_, parsedCert := selfSignedCert(t)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -9,12 +9,33 @@ import socket
 import ssl
 import os
 import platform
+import struct
 import urllib.error
 import urllib.request
 
 LOCALHOST = '127.0.0.1'
 IS_WINDOWS = platform.system() == 'Windows'
 TIMEOUT = int(os.environ.get('GHOSTUNNEL_TEST_TIMEOUT', '10'))
+
+
+def parse_tlvs(data):
+    """Parse a PROXY protocol v2 TLV vector from raw bytes.
+
+    Returns a list of (type, value) tuples."""
+    tlvs = []
+    i = 0
+    while i < len(data):
+        if i + 3 > len(data):
+            raise Exception("truncated TLV at offset {0}".format(i))
+        tlv_type = data[i]
+        tlv_len = struct.unpack('!H', data[i+1:i+3])[0]
+        i += 3
+        if i + tlv_len > len(data):
+            raise Exception("truncated TLV value at offset {0}".format(i))
+        tlv_value = data[i:i+tlv_len]
+        i += tlv_len
+        tlvs.append((tlv_type, tlv_value))
+    return tlvs
 
 
 def _poll_sleep(iteration):

--- a/tests/test-server-proxy-protocol-conn.py
+++ b/tests/test-server-proxy-protocol-conn.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+"""
+Tests that bare --proxy-protocol sends a valid PROXY protocol v2 header
+with connection info only (no TLVs) to the backend.
+"""
+
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, \
+                   TlsClient, print_ok, run_ghostunnel, terminate, \
+                   LISTEN_PORT, TARGET_PORT, TIMEOUT
+import socket
+import struct
+
+# PROXY protocol v2 signature (12 bytes)
+PP2_SIGNATURE = b'\r\n\r\n\x00\r\nQUIT\n'
+
+ghostunnel = None
+try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel with bare --proxy-protocol (conn mode, no TLVs)
+    ghostunnel = run_ghostunnel(['server',
+                                 '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+                                 '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
+                                 '--keystore=server.p12',
+                                 '--cacert=root.crt',
+                                 '--allow-ou=client',
+                                 '--proxy-protocol',
+                                 '--status={0}:{1}'.format(LOCALHOST,
+                                                           STATUS_PORT)])
+
+    # set up backend listener manually
+    backend = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    backend.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    so_reuseport = getattr(socket, 'SO_REUSEPORT', None)
+    if so_reuseport is not None:
+        backend.setsockopt(socket.SOL_SOCKET, so_reuseport, 1)
+    backend.settimeout(TIMEOUT)
+    backend.bind((LOCALHOST, TARGET_PORT))
+    backend.listen(1)
+
+    # wait for ghostunnel to start
+    TcpClient(STATUS_PORT).connect(20)
+
+    # connect a TLS client through the tunnel
+    client = TlsClient('client', 'root', LISTEN_PORT)
+    client.connect()
+
+    # accept the backend connection
+    conn, _ = backend.accept()
+    conn.settimeout(TIMEOUT)
+
+    # read the PROXY protocol v2 header (16 bytes minimum)
+    header = b''
+    while len(header) < 16:
+        chunk = conn.recv(16 - len(header))
+        if not chunk:
+            raise Exception("connection closed before full header received")
+        header += chunk
+
+    # verify signature
+    if header[:12] != PP2_SIGNATURE:
+        raise Exception("invalid PROXY protocol v2 signature")
+    print_ok("PROXY protocol v2 signature verified")
+
+    # verify version and command
+    ver_cmd = header[12]
+    version = (ver_cmd & 0xF0) >> 4
+    command = ver_cmd & 0x0F
+    if version != 2 or command != 1:
+        raise Exception("expected v2 PROXY, got v={0} cmd={1}".format(
+            version, command))
+    print_ok("version=2, command=PROXY verified")
+
+    # verify address family
+    fam_proto = header[13]
+    if fam_proto not in (0x11, 0x21):
+        raise Exception("unexpected family/protocol: 0x{0:02x}".format(fam_proto))
+    print_ok("address family/protocol verified: 0x{0:02x}".format(fam_proto))
+
+    # read remaining payload
+    payload_len = struct.unpack('!H', header[14:16])[0]
+    payload = b''
+    while len(payload) < payload_len:
+        chunk = conn.recv(payload_len - len(payload))
+        if not chunk:
+            raise Exception("connection closed before payload received")
+        payload += chunk
+
+    # parse address data
+    if fam_proto == 0x11:
+        addr_size = 12
+        src_addr = socket.inet_ntoa(payload[0:4])
+        dst_addr = socket.inet_ntoa(payload[4:8])
+        src_port = struct.unpack('!H', payload[8:10])[0]
+        dst_port = struct.unpack('!H', payload[10:12])[0]
+        print_ok("src={0}:{1} dst={2}:{3}".format(
+            src_addr, src_port, dst_addr, dst_port))
+        if src_addr != '127.0.0.1':
+            raise Exception("expected source 127.0.0.1, got {0}".format(src_addr))
+    elif fam_proto == 0x21:
+        addr_size = 36
+    else:
+        addr_size = 0
+    print_ok("PROXY protocol address data verified")
+
+    # verify NO TLVs after address data (conn mode)
+    tlv_data = payload[addr_size:]
+    if len(tlv_data) != 0:
+        raise Exception(
+            "expected no TLVs in conn mode, but got {0} bytes".format(
+                len(tlv_data)))
+    print_ok("no TLVs present (conn mode correct)")
+
+    # send application data and verify it passes through
+    test_data = b'hello proxy protocol conn'
+    client.get_socket().send(test_data)
+    received = conn.recv(len(test_data))
+    if received != test_data:
+        raise Exception("application data mismatch")
+    print_ok("application data passed through correctly after PROXY header")
+
+    conn.close()
+    backend.close()
+    client.cleanup()
+
+    print_ok("OK")
+finally:
+    terminate(ghostunnel)

--- a/tests/test-server-proxy-protocol-tls.py
+++ b/tests/test-server-proxy-protocol-tls.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+"""
+Tests that --proxy-protocol-mode=tls sends a PROXY protocol v2 header
+with TLS metadata TLVs (SSL version, ALPN, SNI) but without client
+certificate details.
+"""
+
+from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, \
+                   TlsClient, print_ok, run_ghostunnel, terminate, \
+                   LISTEN_PORT, TARGET_PORT, TIMEOUT, parse_tlvs
+import socket
+import struct
+
+# PROXY protocol v2 signature (12 bytes)
+PP2_SIGNATURE = b'\r\n\r\n\x00\r\nQUIT\n'
+
+# TLV type constants
+PP2_TYPE_SSL = 0x20
+PP2_SUBTYPE_SSL_VERSION = 0x21
+PP2_SUBTYPE_SSL_CN = 0x22
+PP2_SUBTYPE_SSL_CLIENT_CERT = 0x28
+
+# SSL client flags
+PP2_CLIENT_SSL = 0x01
+PP2_CLIENT_CERT_CONN = 0x02
+PP2_CLIENT_CERT_SESS = 0x04
+
+
+ghostunnel = None
+try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel with --proxy-protocol-mode=tls
+    ghostunnel = run_ghostunnel(['server',
+                                 '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+                                 '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
+                                 '--keystore=server.p12',
+                                 '--cacert=root.crt',
+                                 '--allow-ou=client',
+                                 '--proxy-protocol-mode=tls',
+                                 '--status={0}:{1}'.format(LOCALHOST,
+                                                           STATUS_PORT)])
+
+    # set up backend listener manually
+    backend = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    backend.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    so_reuseport = getattr(socket, 'SO_REUSEPORT', None)
+    if so_reuseport is not None:
+        backend.setsockopt(socket.SOL_SOCKET, so_reuseport, 1)
+    backend.settimeout(TIMEOUT)
+    backend.bind((LOCALHOST, TARGET_PORT))
+    backend.listen(1)
+
+    # wait for ghostunnel to start
+    TcpClient(STATUS_PORT).connect(20)
+
+    # connect a TLS client through the tunnel
+    client = TlsClient('client', 'root', LISTEN_PORT)
+    client.connect()
+
+    # accept the backend connection
+    conn, _ = backend.accept()
+    conn.settimeout(TIMEOUT)
+
+    # read the PROXY protocol v2 header
+    header = b''
+    while len(header) < 16:
+        chunk = conn.recv(16 - len(header))
+        if not chunk:
+            raise Exception("connection closed before full header received")
+        header += chunk
+
+    # verify signature
+    if header[:12] != PP2_SIGNATURE:
+        raise Exception("invalid PROXY protocol v2 signature")
+    print_ok("PROXY protocol v2 signature verified")
+
+    # verify version and command
+    ver_cmd = header[12]
+    version = (ver_cmd & 0xF0) >> 4
+    command = ver_cmd & 0x0F
+    if version != 2 or command != 1:
+        raise Exception("expected v2 PROXY, got v={0} cmd={1}".format(
+            version, command))
+    print_ok("version=2, command=PROXY verified")
+
+    # read remaining payload
+    fam_proto = header[13]
+    payload_len = struct.unpack('!H', header[14:16])[0]
+    payload = b''
+    while len(payload) < payload_len:
+        chunk = conn.recv(payload_len - len(payload))
+        if not chunk:
+            raise Exception("connection closed before payload received")
+        payload += chunk
+
+    # skip address data
+    if fam_proto == 0x11:
+        addr_size = 12
+    elif fam_proto == 0x21:
+        addr_size = 36
+    else:
+        addr_size = 0
+
+    # parse TLVs
+    tlv_data = payload[addr_size:]
+    if len(tlv_data) == 0:
+        raise Exception("no TLVs present in PROXY header (expected TLS metadata)")
+    tlvs = parse_tlvs(tlv_data)
+    tlv_dict = {t: v for t, v in tlvs}
+    print_ok("parsed {0} TLV(s) from PROXY header".format(len(tlvs)))
+
+    # verify PP2_TYPE_SSL is present
+    if PP2_TYPE_SSL not in tlv_dict:
+        raise Exception("PP2_TYPE_SSL not found in TLVs")
+
+    ssl_value = tlv_dict[PP2_TYPE_SSL]
+    if len(ssl_value) < 5:
+        raise Exception("PP2_TYPE_SSL value too short")
+
+    # Parse SSL sub-header flags
+    ssl_flags = ssl_value[0]
+    if not (ssl_flags & PP2_CLIENT_SSL):
+        raise Exception("PP2_CLIENT_SSL flag not set")
+    # In tls mode, cert flags should NOT be set even though a client cert was presented
+    if ssl_flags & PP2_CLIENT_CERT_CONN:
+        raise Exception("PP2_CLIENT_CERT_CONN should not be set in tls mode")
+    print_ok("PP2_TYPE_SSL flags correct for tls mode: 0x{0:02x}".format(ssl_flags))
+
+    # Parse SSL sub-TLVs
+    ssl_sub_tlvs = parse_tlvs(ssl_value[5:])
+    ssl_sub_dict = {t: v for t, v in ssl_sub_tlvs}
+
+    # Should have version
+    if PP2_SUBTYPE_SSL_VERSION not in ssl_sub_dict:
+        raise Exception("PP2_SUBTYPE_SSL_VERSION not found")
+    ssl_version = ssl_sub_dict[PP2_SUBTYPE_SSL_VERSION].decode('ascii')
+    if 'TLS' not in ssl_version:
+        raise Exception("unexpected SSL version: {0}".format(ssl_version))
+    print_ok("SSL version: {0}".format(ssl_version))
+
+    # Should NOT have client cert details
+    if PP2_SUBTYPE_SSL_CN in ssl_sub_dict:
+        raise Exception("PP2_SUBTYPE_SSL_CN should not be present in tls mode")
+    if PP2_SUBTYPE_SSL_CLIENT_CERT in ssl_sub_dict:
+        raise Exception("PP2_SUBTYPE_SSL_CLIENT_CERT should not be present in tls mode")
+    print_ok("no client cert sub-TLVs present (tls mode correct)")
+
+    # send application data and verify
+    test_data = b'hello proxy protocol tls'
+    client.get_socket().send(test_data)
+    received = conn.recv(len(test_data))
+    if received != test_data:
+        raise Exception("application data mismatch")
+    print_ok("application data passed through correctly")
+
+    conn.close()
+    backend.close()
+    client.cleanup()
+
+    print_ok("OK")
+finally:
+    terminate(ghostunnel)

--- a/tests/test-server-proxy-protocol.py
+++ b/tests/test-server-proxy-protocol.py
@@ -1,18 +1,33 @@
 #!/usr/bin/env python3
 
 """
-Tests that --proxy-protocol sends a valid PROXY protocol v2 header
-to the backend before forwarding application data.
+Tests that --proxy-protocol-mode=tls-full sends a PROXY protocol v2 header
+to the backend before forwarding application data, including TLS
+metadata TLVs (SSL, ALPN, Authority, client cert).
 """
 
 from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, \
                    TlsClient, print_ok, run_ghostunnel, terminate, \
-                   LISTEN_PORT, TARGET_PORT, TIMEOUT
+                   LISTEN_PORT, TARGET_PORT, TIMEOUT, parse_tlvs
 import socket
 import struct
 
 # PROXY protocol v2 signature (12 bytes)
 PP2_SIGNATURE = b'\r\n\r\n\x00\r\nQUIT\n'
+
+# TLV type constants
+PP2_TYPE_ALPN = 0x01
+PP2_TYPE_AUTHORITY = 0x02
+PP2_TYPE_SSL = 0x20
+PP2_SUBTYPE_SSL_VERSION = 0x21
+PP2_SUBTYPE_SSL_CN = 0x22
+PP2_SUBTYPE_SSL_CLIENT_CERT = 0x28
+
+# SSL client flags
+PP2_CLIENT_SSL = 0x01
+PP2_CLIENT_CERT_CONN = 0x02
+PP2_CLIENT_CERT_SESS = 0x04
+
 
 ghostunnel = None
 try:
@@ -21,14 +36,14 @@ try:
     root.create_signed_cert('server')
     root.create_signed_cert('client')
 
-    # start ghostunnel with --proxy-protocol
+    # start ghostunnel with --proxy-protocol-mode=tls-full (full TLS metadata + client cert)
     ghostunnel = run_ghostunnel(['server',
                                  '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
                                  '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
                                  '--keystore=server.p12',
                                  '--cacert=root.crt',
                                  '--allow-ou=client',
-                                 '--proxy-protocol',
+                                 '--proxy-protocol-mode=tls-full',
                                  '--status={0}:{1}'.format(LOCALHOST,
                                                            STATUS_PORT)])
 
@@ -71,7 +86,6 @@ try:
     print_ok("PROXY protocol v2 signature verified")
 
     # verify version and command (byte 12)
-    # version = high nibble (should be 0x2), command = low nibble (0x1 = PROXY)
     ver_cmd = header[12]
     version = (ver_cmd & 0xF0) >> 4
     command = ver_cmd & 0x0F
@@ -82,33 +96,103 @@ try:
     print_ok("version=2, command=PROXY verified")
 
     # verify address family and protocol (byte 13)
-    # 0x11 = AF_INET + STREAM, 0x21 = AF_INET6 + STREAM
     fam_proto = header[13]
     if fam_proto not in (0x11, 0x21):
         raise Exception("unexpected family/protocol: 0x{0:02x}".format(fam_proto))
     print_ok("address family/protocol verified: 0x{0:02x}".format(fam_proto))
 
-    # read address data (length is in bytes 14-15)
-    addr_len = struct.unpack('!H', header[14:16])[0]
-    addr_data = b''
-    while len(addr_data) < addr_len:
-        chunk = conn.recv(addr_len - len(addr_data))
+    # read remaining payload (address data + TLVs)
+    payload_len = struct.unpack('!H', header[14:16])[0]
+    payload = b''
+    while len(payload) < payload_len:
+        chunk = conn.recv(payload_len - len(payload))
         if not chunk:
-            raise Exception("connection closed before address data received")
-        addr_data += chunk
+            raise Exception("connection closed before payload received")
+        payload += chunk
 
+    # parse address data
     if fam_proto == 0x11:
-        # IPv4: 4+4+2+2 = 12 bytes (src_addr, dst_addr, src_port, dst_port)
-        if addr_len < 12:
-            raise Exception("IPv4 address data too short: {0}".format(addr_len))
-        src_addr = socket.inet_ntoa(addr_data[0:4])
-        dst_addr = socket.inet_ntoa(addr_data[4:8])
-        src_port = struct.unpack('!H', addr_data[8:10])[0]
-        dst_port = struct.unpack('!H', addr_data[10:12])[0]
+        # IPv4: 4+4+2+2 = 12 bytes
+        addr_size = 12
+        if payload_len < addr_size:
+            raise Exception("IPv4 address data too short: {0}".format(payload_len))
+        src_addr = socket.inet_ntoa(payload[0:4])
+        dst_addr = socket.inet_ntoa(payload[4:8])
+        src_port = struct.unpack('!H', payload[8:10])[0]
+        dst_port = struct.unpack('!H', payload[10:12])[0]
         print_ok("src={0}:{1} dst={2}:{3}".format(src_addr, src_port, dst_addr, dst_port))
         if src_addr != '127.0.0.1':
             raise Exception("expected source 127.0.0.1, got {0}".format(src_addr))
+    elif fam_proto == 0x21:
+        # IPv6: 16+16+2+2 = 36 bytes
+        addr_size = 36
+        if payload_len < addr_size:
+            raise Exception("IPv6 address data too short: {0}".format(payload_len))
+    else:
+        addr_size = 0
     print_ok("PROXY protocol address data verified")
+
+    # parse TLVs from remaining payload after address data
+    tlv_data = payload[addr_size:]
+    if len(tlv_data) == 0:
+        raise Exception("no TLVs present in PROXY header")
+
+    tlvs = parse_tlvs(tlv_data)
+    tlv_dict = {t: v for t, v in tlvs}
+    print_ok("parsed {0} TLV(s) from PROXY header".format(len(tlvs)))
+
+    # --- Verify PP2_TYPE_SSL (0x20) ---
+    if PP2_TYPE_SSL not in tlv_dict:
+        raise Exception("PP2_TYPE_SSL (0x20) not found in TLVs")
+
+    ssl_value = tlv_dict[PP2_TYPE_SSL]
+    if len(ssl_value) < 5:
+        raise Exception("PP2_TYPE_SSL value too short: {0} bytes".format(len(ssl_value)))
+
+    # Parse 5-byte SSL sub-header
+    ssl_flags = ssl_value[0]
+    ssl_verify = struct.unpack('!I', ssl_value[1:5])[0]
+
+    if not (ssl_flags & PP2_CLIENT_SSL):
+        raise Exception("PP2_CLIENT_SSL flag not set")
+    if not (ssl_flags & PP2_CLIENT_CERT_CONN):
+        raise Exception("PP2_CLIENT_CERT_CONN flag not set (client cert was presented)")
+    if ssl_verify != 0:
+        raise Exception("expected verify=0 (success), got {0}".format(ssl_verify))
+    print_ok("PP2_TYPE_SSL flags verified: flags=0x{0:02x}, verify={1}".format(
+        ssl_flags, ssl_verify))
+
+    # Parse nested SSL sub-TLVs
+    ssl_sub_tlvs = parse_tlvs(ssl_value[5:])
+    ssl_sub_dict = {t: v for t, v in ssl_sub_tlvs}
+    print_ok("parsed {0} SSL sub-TLV(s)".format(len(ssl_sub_tlvs)))
+
+    # Verify SSL_VERSION
+    if PP2_SUBTYPE_SSL_VERSION not in ssl_sub_dict:
+        raise Exception("PP2_SUBTYPE_SSL_VERSION not found")
+    ssl_version = ssl_sub_dict[PP2_SUBTYPE_SSL_VERSION].decode('ascii')
+    if 'TLS' not in ssl_version:
+        raise Exception("unexpected SSL version: {0}".format(ssl_version))
+    print_ok("SSL version: {0}".format(ssl_version))
+
+    # Verify SSL_CN (client cert CN)
+    if PP2_SUBTYPE_SSL_CN not in ssl_sub_dict:
+        raise Exception("PP2_SUBTYPE_SSL_CN not found")
+    ssl_cn = ssl_sub_dict[PP2_SUBTYPE_SSL_CN].decode('utf-8')
+    if ssl_cn != 'client':
+        raise Exception("expected CN='client', got '{0}'".format(ssl_cn))
+    print_ok("SSL CN: {0}".format(ssl_cn))
+
+    # Verify SSL_CLIENT_CERT (DER-encoded X.509)
+    if PP2_SUBTYPE_SSL_CLIENT_CERT not in ssl_sub_dict:
+        raise Exception("PP2_SUBTYPE_SSL_CLIENT_CERT not found")
+    client_cert_der = ssl_sub_dict[PP2_SUBTYPE_SSL_CLIENT_CERT]
+    if len(client_cert_der) == 0:
+        raise Exception("client cert DER data is empty")
+    # Basic DER validation: should start with SEQUENCE tag (0x30)
+    if client_cert_der[0] != 0x30:
+        raise Exception("client cert DER doesn't start with SEQUENCE tag")
+    print_ok("SSL client cert: {0} bytes of DER data".format(len(client_cert_der)))
 
     # send application data through the tunnel and verify it arrives
     test_data = b'hello proxy protocol'


### PR DESCRIPTION
Augment PROXY protocol v2 with TLS metadata TLVs:
- Fix IPv6: detect address family at runtime instead of hardcoding TCPv4
- Add PP2_SUBTYPE_SSL_CLIENT_CERT with full DER-encoded client cert
- Add PP2_TYPE_AUTHORITY (SNI) and PP2_TYPE_ALPN top-level TLVs
- Add unit tests for TLV construction and transport protocol detection
- Extend integration test to parse and validate all new TLVs