### PR TITLE
Add version info to docs to show when features became available

### DIFF
--- a/docs/ACCESS-FLAGS.md
+++ b/docs/ACCESS-FLAGS.md
@@ -55,7 +55,7 @@ with `spiffe://ghostunnel/client1` or `spiffe://ghostunnel/client2` URI SANs (as
 well as other values). See documentation for the [wildcard][wildcard] package
 for more information.
 
-* `--allow-policy` and `--allow-query`
+* `--allow-policy` and `--allow-query` (*OPA bundle support since v1.9.0*)
 
 Allow clients where a Rego policy evaluates to `true` with the given query.
 For more information, see the Open Policy Agent section below.
@@ -71,9 +71,10 @@ control flags.
 
 Ghostunnel verifies client certificates before forwarding connections, but
 backends may also need to know the client's identity for their own access
-control, logging, or auditing. Use `--proxy-protocol-mode=tls-full` to forward
-the client certificate (CN, full DER-encoded cert) to the backend via
-[PROXY protocol v2]({{< ref "PROXY-PROTOCOL.md" >}}) TLV extensions.
+control, logging, or auditing. Use `--proxy-protocol-mode=tls-full` (available
+since v1.10.0) to forward the client certificate (CN, full DER-encoded cert) to
+the backend via [PROXY protocol v2]({{< ref "PROXY-PROTOCOL.md" >}}) TLV
+extensions.
 
 ## Client mode
 
@@ -127,7 +128,7 @@ with `spiffe://ghostunnel/server1` or `spiffe://ghostunnel/server2` URI SANs (as
 well as other values). See documentation for the [wildcard][wildcard] package
 for more information.
 
-* `--verify-policy` and `--verify-query`
+* `--verify-policy` and `--verify-query` (*OPA bundle support since v1.9.0*)
 
 Verify that a Rego policy evaluates to `true` with the given query.
 For more information, see the Open Policy Agent section below.
@@ -142,6 +143,8 @@ but the backend doesn't require mutual authentication.
 [wildcard]: https://pkg.go.dev/github.com/ghostunnel/ghostunnel/wildcard
 
 ## Open Policy Agent
+
+*Available since v1.7.0, OPA bundle support available since v1.9.0.*
 
 Ghostunnel has support for [Open Policy Agent][opa] (OPA), both in server and
 client mode. The policy must be provided as an [OPA bundle][opa-bundles] on

--- a/docs/GRACEFUL-SHUTDOWN.md
+++ b/docs/GRACEFUL-SHUTDOWN.md
@@ -35,6 +35,8 @@ reload certificates and OPA policies on a fixed interval.
 
 ### HTTP endpoint (`/_shutdown`)
 
+*Available since v1.8.1.*
+
 If `--enable-shutdown` is set (requires `--status`), you can trigger a
 shutdown via HTTP POST:
 
@@ -91,6 +93,8 @@ connection behavior and may be relevant when tuning shutdown. See
 [Command-Line Flags]({{< ref "FLAGS.md" >}}) for the full list.
 
 ## Integration with systemd
+
+*Available since v1.8.0.*
 
 When running as a systemd service with `Type=notify-reload`, Ghostunnel
 notifies systemd of its state transitions (ready, reloading, stopping). The

--- a/docs/HSM-PKCS11.md
+++ b/docs/HSM-PKCS11.md
@@ -47,8 +47,7 @@ ghostunnel server \
 The `--pkcs11-module`, `--pkcs11-token-label` and `--pkcs11-pin` flags can be
 used to select the private key to be used from the PKCS#11 module. It's also possible
 to use environment variables to set PKCS#11 options instead of flags (via
-`PKCS11_MODULE`, `PKCS11_TOKEN_LABEL` and `PKCS11_PIN`), useful if you don't
-want to show the PIN on the command line.
+`PKCS11_MODULE`, `PKCS11_TOKEN_LABEL` and `PKCS11_PIN`), useful if you don't want to show the PIN on the command line.
 
 Note that `--cert` needs to point to the certificate chain that corresponds
 to the private key in the PKCS#11 module, with the leaf certificate being the

--- a/docs/KEYCHAIN.md
+++ b/docs/KEYCHAIN.md
@@ -121,8 +121,8 @@ Get-ChildItem Cert:\CurrentUser\My | Format-Table Subject, Thumbprint, NotAfter
 on Windows, Ghostunnel searches three stores in this order:
 
 1. **MY** (Current User), the personal certificate store
-2. **CURRENT_SERVICE**, the current service account's certificates (if accessible)
-3. **LOCAL_MACHINE**, machine-wide certificates (if accessible; may require elevation)
+2. **CURRENT_SERVICE**, the current service account's certificates (if accessible, *since v1.8.1*)
+3. **LOCAL_MACHINE**, machine-wide certificates (if accessible; may require elevation, *since v1.8.1*)
 
 Stores that fail to open are skipped rather than causing an error.
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -65,6 +65,8 @@ information on profiling via pprof, see the [`runtime/pprof`][pprof] and
 
 ## Shutdown Endpoint
 
+*Available since v1.8.1.*
+
 If `--enable-shutdown` is set, a `/_shutdown` endpoint is available on the
 status port. Sending an HTTP POST request to this endpoint will trigger a
 graceful shutdown of the Ghostunnel process. Any other HTTP method returns 405

--- a/docs/PROXY-PROTOCOL.md
+++ b/docs/PROXY-PROTOCOL.md
@@ -30,7 +30,7 @@ ghostunnel server \
 ```
 
 To also include TLS metadata and/or client certificate details, use the
-`--proxy-protocol-mode` flag:
+`--proxy-protocol-mode` flag (*available since v1.10.0*):
 
 | Mode | What is sent |
 |------|-------------|

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -98,6 +98,8 @@ localhost risks unauthorized access to the proxied service.
 
 ## Landlock sandboxing
 
+*Available since v1.8.0. Enabled by default since v1.9.0.*
+
 On Linux, Ghostunnel uses [Landlock][landlock] to restrict its own process
 privileges after startup. Landlock is a kernel-level access control mechanism
 that limits which files and network ports a process can access.
@@ -121,6 +123,8 @@ Landlock (network rules require Linux 6.7+), Ghostunnel logs a warning and
 continues without sandboxing.
 
 ### Disabling Landlock
+
+*Available since v1.9.0.*
 
 Landlock can be disabled with `--disable-landlock` if it causes issues with
 your deployment. This is not recommended. Landlock is also automatically

--- a/docs/WATCHDOG.md
+++ b/docs/WATCHDOG.md
@@ -4,6 +4,8 @@ description: Integrate with the systemd watchdog timer for automatic restart on 
 weight: 85
 ---
 
+*Available since v1.8.0.*
+
 Ghostunnel supports systemd's [notify][sd-notify] and watchdog functionality on
 Linux. This allows systemd to know when Ghostunnel is ready and to automatically
 restart it if it becomes unresponsive.


### PR DESCRIPTION
Add version info to docs to show when features became available. Helps avoid confusion on what's available. Just doing this for the last 3 or so years for releases, don't think we need to go back more than that. 