### PR TITLE
Windows event log implementation

### DIFF
--- a/certloader/certstore_disabled.go
+++ b/certloader/certstore_disabled.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows
+//go:build !cgo || (!darwin && !windows)
 
 /*-
  * Copyright 2018 Square Inc.

--- a/certloader/certstore_enabled.go
+++ b/certloader/certstore_enabled.go
@@ -1,4 +1,4 @@
-//go:build darwin || windows
+//go:build cgo && (darwin || windows)
 
 /*-
  * Copyright 2018 Square Inc.

--- a/certloader/certstore_enabled_test.go
+++ b/certloader/certstore_enabled_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || windows
+//go:build cgo && (darwin || windows)
 
 package certloader
 

--- a/certloader/certstore_reload_test.go
+++ b/certloader/certstore_reload_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || windows
+//go:build cgo && (darwin || windows)
 
 package certloader
 

--- a/certstore/certstore_other.go
+++ b/certstore/certstore_other.go
@@ -1,3 +1,5 @@
+//go:build !cgo || (!darwin && !windows)
+
 package certstore
 
 import (

--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build cgo && (darwin || windows)
 
 package certstore
 

--- a/certstore/errors_darwin_test.go
+++ b/certstore/errors_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package certstore
 

--- a/certstore/main_test.go
+++ b/certstore/main_test.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build cgo && (darwin || windows)
 
 package certstore
 

--- a/certstore/testca_test.go
+++ b/certstore/testca_test.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build cgo && (darwin || windows)
 
 package certstore
 

--- a/docs/FLAGS.md
+++ b/docs/FLAGS.md
@@ -82,6 +82,7 @@ metrics endpoints, and profiling.
 | `--enable-shutdown` | Enable `/_shutdown` endpoint alongside `/_status` to allow terminating via HTTP POST. | All platforms |
 | `--quiet` | Silence log messages. Values: `all`, `conns`, `conn-errs`, `handshake-errs`. Can be repeated. | All platforms |
 | `--syslog` | Send logs to syslog instead of stdout. | Linux, macOS |
+| `--eventlog` | Send logs to Windows Event Log instead of stdout. | Windows |
 | `--skip-resolve` | Skip resolving target host on startup (useful to start before network is up). | All platforms |
 
 ### Landlock

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.7.0
 )
 
+require github.com/pkg/errors v0.9.1 // indirect
+
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
@@ -266,7 +268,7 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.42.0
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,9 @@ github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9F
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pires/go-proxyproto v0.11.0 h1:gUQpS85X/VJMdUsYyEgyn59uLJvGqPhJV5YvG68wXH4=
 github.com/pires/go-proxyproto v0.11.0/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ import (
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	graphite "github.com/cyberdelia/go-metrics-graphite"
-	gsyslog "github.com/hashicorp/go-syslog"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	metrics "github.com/rcrowley/go-metrics"
 	sqmetrics "github.com/square/go-sq-metrics"
@@ -210,21 +210,18 @@ type Environment struct {
 // Global logger instance
 var logger = log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
 
-func initLogger(syslog bool, flags []string) (err error) {
-	// If user has indicated request for syslog, override default stdout
-	// logger with a syslog one instead. This can fail, e.g. in containers
-	// that don't have syslog available.
+func initLogger(systemLog bool, flags []string) (err error) {
+	// If user has indicated request for system log (syslog on Unix, event
+	// log on Windows), override default stdout logger with the platform
+	// system logger instead. This can fail, e.g. in containers that don't
+	// have syslog available.
 	if slices.Contains(flags, "all") {
 		// If --quiet=all if passed, disable all logging
 		logger = log.New(io.Discard, "", 0)
 		return
 	}
-	if syslog {
-		var syslogWriter gsyslog.Syslogger
-		syslogWriter, err = gsyslog.NewLogger(gsyslog.LOG_INFO, "DAEMON", "")
-		if err == nil {
-			logger = log.New(syslogWriter, "", log.LstdFlags|log.Lmicroseconds)
-		}
+	if systemLog {
+		err = initSystemLogger()
 	}
 	return
 }
@@ -500,7 +497,7 @@ func run(args []string) error {
 	}
 
 	// Logger
-	err := initLogger(useSyslog(), *quiet)
+	err := initLogger(useSystemLog(), *quiet)
 	if err != nil {
 		return fmt.Errorf("unable to set up logger: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -104,19 +104,21 @@ func TestInitLoggerQuiet(t *testing.T) {
 	assert.NotNil(t, logger, "logger should never be nil after init")
 }
 
-func TestInitLoggerSyslog(t *testing.T) {
+func TestInitLoggerSystemLog(t *testing.T) {
 	originalLogger := logger
+	defer func() { logger = originalLogger }()
+
 	err := initLogger(true, []string{})
-	updatedLogger := logger
 	if err != nil {
 		// Tests running in containers often don't have access to syslog,
 		// so we can't depend on syslog being available for testing. If we
 		// get an error from the syslog setup we just warn and skip test.
-		t.Logf("Error setting up syslog for test, skipping: %s", err)
+		t.Logf("System log not available for test, skipping: %s", err)
+		assert.NotNil(t, logger, "logger should never be nil even after error")
 		t.SkipNow()
 		return
 	}
-	assert.NotEqual(t, originalLogger, updatedLogger, "should have updated logger object")
+	assert.NotEqual(t, originalLogger, logger, "should have updated logger object")
 	assert.NotNil(t, logger, "logger should never be nil after init")
 }
 

--- a/socket/launchd_disabled.go
+++ b/socket/launchd_disabled.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin || !cgo
 
 /*-
  * Copyright 2019 Square Inc.

--- a/socket/launchd_enabled.go
+++ b/socket/launchd_enabled.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 /*-
  * Copyright 2019 Square Inc.

--- a/tests/test-server-system-log.py
+++ b/tests/test-server-system-log.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+"""
+Tests that ghostunnel server works with platform-specific system logging
+(--syslog on Unix/macOS, --eventlog on Windows).
+"""
+
+import sys
+
+from common import (IS_WINDOWS, LISTEN_PORT, TARGET_PORT, SocketPair,
+                    TcpServer, TlsClient, create_default_certs, print_ok,
+                    start_ghostunnel_server, terminate, wait_for_status)
+
+if IS_WINDOWS:
+    system_log_flag = '--eventlog'
+else:
+    system_log_flag = '--syslog'
+
+ghostunnel = None
+root = None
+try:
+    root = create_default_certs()
+    ghostunnel = start_ghostunnel_server(extra_args=[system_log_flag])
+
+    try:
+        wait_for_status(lambda info: True, timeout=10)
+    except TimeoutError:
+        print('ghostunnel failed to start with {0}, skipping'.format(
+            system_log_flag), file=sys.stderr)
+        sys.exit(2)
+
+    # validate tunnel works with system logging enabled
+    pair = SocketPair(
+        TlsClient('client', 'root', LISTEN_PORT), TcpServer(TARGET_PORT))
+    pair.validate_can_send_from_client("hello", "client -> server")
+    pair.validate_can_send_from_server("world", "server -> client")
+    pair.validate_closing_client_closes_server("client close -> server close")
+
+    print_ok("OK")
+finally:
+    terminate(ghostunnel)
+    if root:
+        root.cleanup()

--- a/unix.go
+++ b/unix.go
@@ -19,8 +19,11 @@
 package main
 
 import (
+	"log"
 	"os"
 	"syscall"
+
+	gsyslog "github.com/hashicorp/go-syslog"
 )
 
 var (
@@ -29,6 +32,15 @@ var (
 	syslogFlag      = app.Flag("syslog", "Send logs to syslog instead of stdout (Unix/macOS only).").Bool()
 )
 
-func useSyslog() bool {
+func useSystemLog() bool {
 	return *syslogFlag
+}
+
+func initSystemLogger() error {
+	w, err := gsyslog.NewLogger(gsyslog.LOG_INFO, "DAEMON", "")
+	if err != nil {
+		return err
+	}
+	logger = log.New(w, "", log.LstdFlags|log.Lmicroseconds)
+	return nil
 }

--- a/unix_test.go
+++ b/unix_test.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUseSystemLog(t *testing.T) {
+	assert.False(t, useSystemLog(), "useSystemLog should default to false")
+}
+
+func TestInitSystemLoggerSuccess(t *testing.T) {
+	originalLogger := logger
+	defer func() { logger = originalLogger }()
+
+	err := initSystemLogger()
+	if err != nil {
+		t.Logf("syslog not available, skipping: %s", err)
+		t.SkipNow()
+		return
+	}
+	assert.NotEqual(t, originalLogger, logger, "logger should be updated")
+	assert.NotNil(t, logger)
+}

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - tip
+
+script:
+  - make check

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/Makefile
+++ b/vendor/github.com/pkg/errors/Makefile
@@ -1,0 +1,44 @@
+PKGS := github.com/pkg/errors
+SRCDIRS := $(shell go list -f '{{.Dir}}' $(PKGS))
+GO := go
+
+check: test vet gofmt misspell unconvert staticcheck ineffassign unparam
+
+test: 
+	$(GO) test $(PKGS)
+
+vet: | test
+	$(GO) vet $(PKGS)
+
+staticcheck:
+	$(GO) get honnef.co/go/tools/cmd/staticcheck
+	staticcheck -checks all $(PKGS)
+
+misspell:
+	$(GO) get github.com/client9/misspell/cmd/misspell
+	misspell \
+		-locale GB \
+		-error \
+		*.md *.go
+
+unconvert:
+	$(GO) get github.com/mdempsky/unconvert
+	unconvert -v $(PKGS)
+
+ineffassign:
+	$(GO) get github.com/gordonklaus/ineffassign
+	find $(SRCDIRS) -name '*.go' | xargs ineffassign
+
+pedantic: check errcheck
+
+unparam:
+	$(GO) get mvdan.cc/unparam
+	unparam ./...
+
+errcheck:
+	$(GO) get github.com/kisielk/errcheck
+	errcheck $(PKGS)
+
+gofmt:  
+	@echo Checking code is gofmted
+	@test -z "$(shell gofmt -s -l -d -e $(SRCDIRS) | tee /dev/stderr)"

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,59 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Roadmap
+
+With the upcoming [Go2 error proposals](https://go.googlesource.com/proposal/+/master/design/go2draft.md) this package is moving into maintenance mode. The roadmap for a 1.0 release is as follows:
+
+- 0.9. Remove pre Go 1.9 and Go 1.10 support, address outstanding pull requests (if possible)
+- 1.0. Final release.
+
+## Contributing
+
+Because of the Go2 errors changes, this package is not accepting proposals for new functionality. With that said, we welcome pull requests, bug fixes and issue reports. 
+
+Before sending a PR, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,288 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d\n", f, f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/go113.go
+++ b/vendor/github.com/pkg/errors/go113.go
@@ -1,0 +1,38 @@
+// +build go1.13
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,177 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+// For historical reasons if Frame is interpreted as a uintptr
+// its value represents the program counter + 1.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// name returns the name of this function, if known.
+func (f Frame) name() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	return fn.Name()
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			io.WriteString(s, f.name())
+			io.WriteString(s, "\n\t")
+			io.WriteString(s, f.file())
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		io.WriteString(s, strconv.Itoa(f.line()))
+	case 'n':
+		io.WriteString(s, funcname(f.name()))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// MarshalText formats a stacktrace Frame as a text string. The output is the
+// same as that of fmt.Sprintf("%+v", f), but without newlines or tabs.
+func (f Frame) MarshalText() ([]byte, error) {
+	name := f.name()
+	if name == "unknown" {
+		return []byte(name), nil
+	}
+	return []byte(fmt.Sprintf("%s %s:%d", name, f.file(), f.line())), nil
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				io.WriteString(s, "\n")
+				f.Format(s, verb)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			st.formatSlice(s, verb)
+		}
+	case 's':
+		st.formatSlice(s, verb)
+	}
+}
+
+// formatSlice will format this StackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st StackTrace) formatSlice(s fmt.State, verb rune) {
+	io.WriteString(s, "[")
+	for i, f := range st {
+		if i > 0 {
+			io.WriteString(s, " ")
+		}
+		f.Format(s, verb)
+	}
+	io.WriteString(s, "]")
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -956,6 +956,9 @@ github.com/pierrec/lz4/internal/xxh32
 # github.com/pires/go-proxyproto v0.11.0
 ## explicit; go 1.24
 github.com/pires/go-proxyproto
+# github.com/pkg/errors v0.9.1
+## explicit
+github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib

--- a/windows.go
+++ b/windows.go
@@ -59,7 +59,11 @@ func (w *eventLogWriter) Write(p []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return len(p), windows.ReportEvent(w.handle, windows.EVENTLOG_INFORMATION_TYPE, 0, 1, 0, 1, 0, &msgPtr, nil)
+	err = windows.ReportEvent(w.handle, windows.EVENTLOG_INFORMATION_TYPE, 0, 1, 0, 1, 0, &msgPtr, nil)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
 }
 
 func (w *eventLogWriter) Close() error {

--- a/windows.go
+++ b/windows.go
@@ -19,14 +19,58 @@
 package main
 
 import (
+	"bytes"
+	"log"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
 	shutdownSignals = []os.Signal{os.Interrupt}
 	refreshSignals  = []os.Signal{ /* Not supported on Windows */ }
+	eventlogFlag    = app.Flag("eventlog", "Send logs to Windows Event Log instead of stdout (Windows only).").Bool()
 )
 
-func useSyslog() bool {
-	return false
+func useSystemLog() bool {
+	return *eventlogFlag
+}
+
+// eventLogWriter implements io.Writer for the Windows Event Log.
+type eventLogWriter struct {
+	handle windows.Handle
+}
+
+func newEventLogWriter(source string) (*eventLogWriter, error) {
+	srcPtr, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return nil, err
+	}
+	h, err := windows.RegisterEventSource(nil, srcPtr)
+	if err != nil {
+		return nil, err
+	}
+	return &eventLogWriter{handle: h}, nil
+}
+
+func (w *eventLogWriter) Write(p []byte) (int, error) {
+	msg := string(bytes.TrimRight(p, "\n"))
+	msgPtr, err := windows.UTF16PtrFromString(msg)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), windows.ReportEvent(w.handle, windows.EVENTLOG_INFORMATION_TYPE, 0, 1, 0, 1, 0, &msgPtr, nil)
+}
+
+func (w *eventLogWriter) Close() error {
+	return windows.DeregisterEventSource(w.handle)
+}
+
+func initSystemLogger() error {
+	w, err := newEventLogWriter("ghostunnel")
+	if err != nil {
+		return err
+	}
+	logger = log.New(w, "", log.LstdFlags|log.Lmicroseconds)
+	return nil
 }

--- a/windows_test.go
+++ b/windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUseSystemLog(t *testing.T) {
+	assert.False(t, useSystemLog(), "useSystemLog should default to false")
+}
+
+func TestEventLogWriterWriteAndClose(t *testing.T) {
+	w, err := newEventLogWriter("Application")
+	if err != nil {
+		t.Fatalf("newEventLogWriter failed: %s", err)
+	}
+	defer w.Close()
+
+	n, err := w.Write([]byte("ghostunnel test message\n"))
+	assert.Nil(t, err)
+	assert.Equal(t, len("ghostunnel test message\n"), n)
+}
+
+func TestInitSystemLogger(t *testing.T) {
+	originalLogger := logger
+	defer func() { logger = originalLogger }()
+
+	err := initSystemLogger()
+	if err != nil {
+		t.Fatalf("initSystemLogger failed: %s", err)
+	}
+	assert.NotEqual(t, originalLogger, logger, "logger should be updated")
+	assert.NotNil(t, logger)
+}


### PR DESCRIPTION
Windows event log implementation: adds a new `--eventlog` flag to enable sending logs to Windows event log, similar to how `--syslog` works on Linux/macOS. Also updated build tags to allow for cross-compiling for Windows with CGO disabled, makes things easier to verify locally. 