### PR TITLE
Detect and report service start failure in service install/start

### DIFF
--- a/windows_service.go
+++ b/windows_service.go
@@ -187,6 +187,39 @@ func checkGhostunnelMarker(name string) error {
 	return nil
 }
 
+// waitForServiceRunning polls the service status after a start command, waiting
+// up to 10 seconds for it to reach the Running state. Returns an error if the
+// service stops or fails to reach Running within the timeout.
+func waitForServiceRunning(s *mgr.Service, name string) error {
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		status, err := s.Query()
+		if err != nil {
+			return fmt.Errorf("could not query service %q status: %w", name, err)
+		}
+		switch status.State {
+		case svc.Running:
+			// Brief stabilization: the service may crash immediately after
+			// reporting Running (e.g. flag parse failure calls os.Exit).
+			time.Sleep(300 * time.Millisecond)
+			status, err = s.Query()
+			if err != nil {
+				return fmt.Errorf("could not query service %q status: %w", name, err)
+			}
+			if status.State == svc.Stopped {
+				return fmt.Errorf("service %q stopped immediately after start; check service arguments", name)
+			}
+			return nil
+		case svc.Stopped:
+			return fmt.Errorf("service %q stopped immediately after start; check service arguments", name)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for service %q to reach running state", name)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
 // stopServiceWithTimeout sends a stop control to the service and waits up to
 // 30 seconds for it to reach the Stopped state.
 func stopServiceWithTimeout(s *mgr.Service, name string) error {
@@ -244,9 +277,13 @@ func doInstallService(name string, proxyArgs []string) error {
 
 	// Register an event source so Windows Event Log doesn't show
 	// "The description for Event ID X from source ghostunnel cannot be found."
-	if err := eventlog.InstallAsEventCreate(name, eventlog.Error|eventlog.Warning|eventlog.Info); err != nil {
-		// Non-fatal: the service will still work, log entries just look ugly.
-		fmt.Fprintf(os.Stderr, "warning: could not register event log source: %v\n", err)
+	// On reinstall the source already exists; skip registration to avoid a spurious warning.
+	if elog, err := eventlog.Open(name); err != nil {
+		if err := eventlog.InstallAsEventCreate(name, eventlog.Error|eventlog.Warning|eventlog.Info); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not register event log source: %v\n", err)
+		}
+	} else {
+		elog.Close()
 	}
 
 	// Write a registry marker so uninstall can confirm this service was
@@ -267,6 +304,15 @@ func doInstallService(name string, proxyArgs []string) error {
 
 	if err := s.Start(); err != nil {
 		return fmt.Errorf("service %q: %w: %w", name, errServiceNotStarted, err)
+	}
+
+	if err := waitForServiceRunning(s, name); err != nil {
+		if elog, elogErr := eventlog.Open(name); elogErr == nil {
+			_ = elog.Error(1, fmt.Sprintf("ghostunnel service install failed: %v", err))
+			elog.Close()
+		}
+		_ = s.Delete()
+		return fmt.Errorf("%w; service registration has been removed, fix the issue and re-run 'service install'", err)
 	}
 
 	fmt.Printf("Service %q installed and started successfully.\n", name)
@@ -335,6 +381,10 @@ func doStartService(name string) error {
 
 	if err := s.Start(); err != nil {
 		return fmt.Errorf("could not start service %q: %w", name, err)
+	}
+
+	if err := waitForServiceRunning(s, name); err != nil {
+		return err
 	}
 
 	fmt.Printf("Service %q started successfully.\n", name)


### PR DESCRIPTION
## Summary

- Poll the SCM after `s.Start()` and return an error if the service stops immediately (e.g. bad arguments passed via `service install -- ...`), instead of silently reporting success
- Add a 300ms stabilization check after first seeing `Running` to catch the race where the service reports Running and then immediately crashes (the `Execute` function sends `Running` before `run()` finishes)
- Roll back the service registration (`s.Delete()`) on install failure so the user can fix their arguments and re-run `service install` without getting a "service already exists" error
- Write an Event Log error entry before rollback so there is a record of the failure
- Suppress the spurious "event source already exists" warning on reinstall by checking `eventlog.Open` before calling `InstallAsEventCreate`

## Test plan

- [ ] `ghostunnel service install -- client --listen localhost:1234 --target host:443 --bad-flag` should now return an error and clean up the service registration
- [ ] `ghostunnel service install -- client --listen localhost:1234 --target host:443 <valid args>` should still succeed
- [ ] Reinstalling an already-installed service should not print an event source warning
- [ ] `ghostunnel service start` with a stopped service that has bad args should return an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)