### PR TITLE
Fix landlock silently dropping unix-socket FS rules

### DIFF
--- a/landlock_linux.go
+++ b/landlock_linux.go
@@ -251,13 +251,20 @@ func setupLandlock() error {
 // inside go-landlock and is silently dropped.
 func ruleFromStringAddress(addr string, ruleFromPort portRuleFunc) (landlock.Rule, landlock.Rule, error) {
 	if strings.HasPrefix(addr, "unix:") {
+		path := addr[5:]
+		if path == "" {
+			// socket.ParseAddress accepts "unix:" with an empty path;
+			// reject here so we don't silently grant RW on the CWD via
+			// filepath.Dir("") == "." before the bind error surfaces.
+			return nil, nil, errors.New("unix socket path is empty")
+		}
 		// Grant RW on the parent directory rather than the socket file
 		// itself: the file does not exist at bind(2) time, and shutdown
 		// may unlink it. No IgnoreIfMissing — if the operator-supplied
 		// parent is missing at startup, fail loud (landlock setup errors
 		// and the warning at the call site fires) rather than silently
 		// dropping the rule and denying bind/connect later.
-		return landlock.RWDirs(filepath.Dir(addr[5:])), nil, nil
+		return landlock.RWDirs(filepath.Dir(path)), nil, nil
 	}
 	if strings.HasPrefix(addr, "systemd:") || strings.HasPrefix(addr, "launchd:") {
 		// Socket activation - no rule needed

--- a/landlock_linux.go
+++ b/landlock_linux.go
@@ -126,12 +126,15 @@ func setupLandlock() error {
 			continue
 		}
 
-		rule, err := ruleFromStringAddress(*addr, landlock.BindTCP)
+		fsRule, netRule, err := ruleFromStringAddress(*addr, landlock.BindTCP)
 		if err != nil {
 			return fmt.Errorf("error processing argument '%s' for landlock rule: %w", *addr, err)
 		}
-		if rule != nil {
-			netRules = append(netRules, rule)
+		if fsRule != nil {
+			fsRules = append(fsRules, fsRule)
+		}
+		if netRule != nil {
+			netRules = append(netRules, netRule)
 		}
 	}
 
@@ -148,12 +151,15 @@ func setupLandlock() error {
 			continue
 		}
 
-		rule, err := ruleFromStringAddress(*addr, landlock.ConnectTCP)
+		fsRule, netRule, err := ruleFromStringAddress(*addr, landlock.ConnectTCP)
 		if err != nil {
 			return fmt.Errorf("error processing argument '%s' for landlock rule: %w", *addr, err)
 		}
-		if rule != nil {
-			netRules = append(netRules, rule)
+		if fsRule != nil {
+			fsRules = append(fsRules, fsRule)
+		}
+		if netRule != nil {
+			netRules = append(netRules, netRule)
 		}
 	}
 
@@ -235,36 +241,48 @@ func setupLandlock() error {
 }
 
 // ruleFromStringAddress turns a flag-supplied address string into a landlock
-// rule. Handles unix sockets (RW on the socket path), systemd/launchd socket
-// activation (no rule needed; the FD is inherited), HTTP/HTTPS URLs, and
-// host:port forms. ruleFromPort selects bind vs connect semantics.
-func ruleFromStringAddress(addr string, ruleFromPort portRuleFunc) (landlock.Rule, error) {
+// rule. Handles unix sockets (RW on the socket's parent dir), systemd/launchd
+// socket activation (no rule needed; the FD is inherited), HTTP/HTTPS URLs,
+// and host:port forms. ruleFromPort selects bind vs connect semantics.
+//
+// Returns at most one non-nil rule: an FS rule for unix-socket addresses,
+// otherwise a net rule. Callers must dispatch each into the correct slice —
+// passing an FS rule to RestrictNet (or vice versa) intersects to zero access
+// inside go-landlock and is silently dropped.
+func ruleFromStringAddress(addr string, ruleFromPort portRuleFunc) (landlock.Rule, landlock.Rule, error) {
 	if strings.HasPrefix(addr, "unix:") {
-		return landlock.RWFiles(addr[5:]), nil
+		// Grant RW on the parent directory rather than the socket file
+		// itself: the file does not exist at bind(2) time, and shutdown
+		// may unlink it. No IgnoreIfMissing — if the operator-supplied
+		// parent is missing at startup, fail loud (landlock setup errors
+		// and the warning at the call site fires) rather than silently
+		// dropping the rule and denying bind/connect later.
+		return landlock.RWDirs(filepath.Dir(addr[5:])), nil, nil
 	}
 	if strings.HasPrefix(addr, "systemd:") || strings.HasPrefix(addr, "launchd:") {
 		// Socket activation - no rule needed
-		return nil, nil
+		return nil, nil, nil
 	}
 	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") {
 		u, err := url.Parse(addr)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return ruleFromURL(u, ruleFromPort)
+		rule, err := ruleFromURL(u, ruleFromPort)
+		return nil, rule, err
 	}
 	parts := strings.Split(addr, ":")
 	if len(parts) < 2 {
-		return nil, errors.New("unable to extract port number from address")
+		return nil, nil, errors.New("unable to extract port number from address")
 	}
 	port, err := strconv.ParseUint(parts[len(parts)-1], 10, 16)
 	if err != nil {
-		return nil, errors.New("unable to extract port number from address")
+		return nil, nil, errors.New("unable to extract port number from address")
 	}
 	if port == 0 {
-		return nil, errors.New("unable to extract port number from address")
+		return nil, nil, errors.New("unable to extract port number from address")
 	}
-	return ruleFromPort(uint16(port)), nil
+	return nil, ruleFromPort(uint16(port)), nil
 }
 
 // ruleFromTCPAddress turns a *net.TCPAddr (from already-parsed flags like

--- a/landlock_test.go
+++ b/landlock_test.go
@@ -30,42 +30,63 @@ import (
 )
 
 func TestLandlockRuleFromStringAddress(t *testing.T) {
+	// kind names which of (fs, net) is expected to be non-nil.
+	type kind int
+	const (
+		none    kind = iota // both nil, no error (systemd:/launchd:)
+		fsOnly              // FS rule, net nil — unix sockets
+		netOnly             // net rule, fs nil — TCP / URL forms
+		invalid             // both nil, err non-nil
+	)
 	testCases := []struct {
-		addr  string
-		valid bool
+		addr string
+		want kind
 	}{
-		{"unix:/tmp/test", true},
-		{"systemd:test", false}, // no rule needed
-		{"launchd:test", false}, // no rule needed
-		{"1.2.3.4:5", true},
-		{"asdf:50", true},
-		{"[1fff:0:a88:85a3::ac1f]:8001", true},
-		{"foobar:80", true},
-		{"foobar", false},              // invalid port
-		{"foobar:foobar", false},       // invalid port
-		{"foobar:100000000000", false}, // invalid port
-		{"foobar:0", false},            // invalid port
-		{"http://127.0.0.1:8001/something", true},
-		{"https://127.0.0.1:8001/something", true},
-		{"http://[1fff:0:a88:85a3::ac1f]:8001/something", true},
-		{"https://[1fff:0:a88:85a3::ac1f]:8001/something", true},
-		{"http://localhost", true},
-		{"https://localhost", true},
-		{"http://_:_!", false},                            // invalid domain
-		{"https://_:_!", false},                           // invalid domain
-		{"http://127.0.0.1:0/something", false},           // invalid port
-		{"https://127.0.0.1:1000000000/something", false}, // invalid port
-		{"!", false},                                      // invalid string
-		{"", false},                                       // invalid string
+		{"unix:/tmp/test", fsOnly},
+		{"unix:/var/lib/myapp/in.sock", fsOnly}, // non-default path — the regression case
+		{"systemd:test", none},
+		{"launchd:test", none},
+		{"1.2.3.4:5", netOnly},
+		{"asdf:50", netOnly},
+		{"[1fff:0:a88:85a3::ac1f]:8001", netOnly},
+		{"foobar:80", netOnly},
+		{"foobar", invalid},
+		{"foobar:foobar", invalid},
+		{"foobar:100000000000", invalid},
+		{"foobar:0", invalid},
+		{"http://127.0.0.1:8001/something", netOnly},
+		{"https://127.0.0.1:8001/something", netOnly},
+		{"http://[1fff:0:a88:85a3::ac1f]:8001/something", netOnly},
+		{"https://[1fff:0:a88:85a3::ac1f]:8001/something", netOnly},
+		{"http://localhost", netOnly},
+		{"https://localhost", netOnly},
+		{"http://_:_!", invalid},
+		{"https://_:_!", invalid},
+		{"http://127.0.0.1:0/something", invalid},
+		{"https://127.0.0.1:1000000000/something", invalid},
+		{"!", invalid},
+		{"", invalid},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.addr, func(t *testing.T) {
-			rule, _ := ruleFromStringAddress(tc.addr, landlock.ConnectTCP)
-			if tc.valid && rule == nil {
-				t.Errorf("no result on valid input")
-			}
-			if !tc.valid && rule != nil {
-				t.Errorf("got result on invalid input")
+			fsRule, netRule, err := ruleFromStringAddress(tc.addr, landlock.ConnectTCP)
+			switch tc.want {
+			case none:
+				if fsRule != nil || netRule != nil || err != nil {
+					t.Errorf("want both nil, got fs=%v net=%v err=%v", fsRule, netRule, err)
+				}
+			case fsOnly:
+				if fsRule == nil || netRule != nil || err != nil {
+					t.Errorf("want fs rule only, got fs=%v net=%v err=%v", fsRule, netRule, err)
+				}
+			case netOnly:
+				if fsRule != nil || netRule == nil || err != nil {
+					t.Errorf("want net rule only, got fs=%v net=%v err=%v", fsRule, netRule, err)
+				}
+			case invalid:
+				if fsRule != nil || netRule != nil {
+					t.Errorf("want no rule on invalid input, got fs=%v net=%v", fsRule, netRule)
+				}
 			}
 		})
 	}

--- a/landlock_test.go
+++ b/landlock_test.go
@@ -44,6 +44,7 @@ func TestLandlockRuleFromStringAddress(t *testing.T) {
 	}{
 		{"unix:/tmp/test", fsOnly},
 		{"unix:/var/lib/myapp/in.sock", fsOnly}, // non-default path — the regression case
+		{"unix:", invalid},                      // empty path — would otherwise grant RW on CWD
 		{"systemd:test", none},
 		{"launchd:test", none},
 		{"1.2.3.4:5", netOnly},
@@ -84,8 +85,8 @@ func TestLandlockRuleFromStringAddress(t *testing.T) {
 					t.Errorf("want net rule only, got fs=%v net=%v err=%v", fsRule, netRule, err)
 				}
 			case invalid:
-				if fsRule != nil || netRule != nil {
-					t.Errorf("want no rule on invalid input, got fs=%v net=%v", fsRule, netRule)
+				if fsRule != nil || netRule != nil || err == nil {
+					t.Errorf("want error on invalid input, got fs=%v net=%v err=%v", fsRule, netRule, err)
 				}
 			}
 		})


### PR DESCRIPTION
`ruleFromStringAddress` returned an FSRule for `unix:` addresses but both call sites appended it to `netRules`, which `RestrictNet` intersects with `handledAccessFS=0`. Thus the rule was silently dropped. Sockets in non-default paths (outside `/run`, `/tmp`, etc.) were denied at bind/connect. Split the return into (`fsRule`, `netRule`) so we know the type. Widen the unix rule from `RWFiles(path)` to `RWDirs(parent).IgnoreIfMissing()` to cover bind(2) and unlink(2) on shutdown, matching rulesFromFile. This was not caught in integration tests because they write to `/tmp`, which is on the default list. First introduced in v1.8.0. 