### PR TITLE
Fix ACME renewal under mTLS

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -13,7 +13,8 @@ RUN apt-get update && \
     apt-get install -y build-essential python3-minimal netcat-traditional softhsm2 rsyslog git openssl default-jre-headless </dev/null && \
     mkdir -p /etc/softhsm /var/lib/softhsm/tokens /go/src/github.com/ghostunnel/ghostunnel && \
     go install golang.org/x/tools/cmd/cover@latest && \
-    go install github.com/magefile/mage@latest
+    go install github.com/magefile/mage@latest && \
+    go install github.com/letsencrypt/pebble/v2/cmd/pebble@latest
 
 WORKDIR /go/src/github.com/ghostunnel/ghostunnel
 

--- a/certloader/acmetlsconfig.go
+++ b/certloader/acmetlsconfig.go
@@ -207,5 +207,40 @@ func (a *acmeTLSConfig) GetServerConfig() *tls.Config {
 	config.GetCertificate = a.magicConfig.GetCertificate
 	config.ClientCAs = a.source.getTrustStore()
 	config.NextProtos = append(config.NextProtos, acmez.ACMETLS1Protocol)
+
+	// The ACME CA's TLS-ALPN-01 validator opens a probe handshake with
+	// SupportedProtos=["acme-tls/1"] (per RFC 8737) and no client certificate.
+	// If the base config requires a client cert (ghostunnel's mTLS default),
+	// that probe fails and renewal silently breaks. Relax ClientAuth for that
+	// exact ALPN only — every real client still gets the base mTLS enforcement.
+	//
+	// Tightening to prevent mTLS bypass — mirror certmagic's own gate at
+	// vendor/github.com/caddyserver/certmagic/handshake.go: relax only when
+	// the ClientHello matches the shape RFC 8737 mandates for a validator.
+	//   - SNI is set. RFC 8737 §3 requires the validator to send the SNI of
+	//     the domain being validated, and certmagic refuses to serve the
+	//     challenge cert without it.
+	//   - SupportedProtos is *exactly* ["acme-tls/1"]. A client sending
+	//     ["acme-tls/1", "h2"] is not a validator and must not relax.
+	//   - Force NextProtos=["acme-tls/1"] in the relaxed config so ALPN
+	//     cannot negotiate to a different protocol on the relaxed handshake.
+	//   - Disable session tickets so a ticket issued during a probe cannot
+	//     be resumed by a real client to skip mTLS. (tls.Config has no
+	//     server-side session cache field; SessionTicketsDisabled is the
+	//     full server-side disable.)
+	config.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+		if chi.ServerName == "" ||
+			len(chi.SupportedProtos) != 1 ||
+			chi.SupportedProtos[0] != acmez.ACMETLS1Protocol {
+			return nil, nil
+		}
+		c := config.Clone()
+		c.ClientAuth = tls.NoClientCert
+		c.ClientCAs = nil
+		c.NextProtos = []string{acmez.ACMETLS1Protocol}
+		c.SessionTicketsDisabled = true
+		return c, nil
+	}
+
 	return config
 }

--- a/certloader/acmetlsconfig.go
+++ b/certloader/acmetlsconfig.go
@@ -47,6 +47,12 @@ type ACMEConfig struct {
 	// Maximum number of attempts to obtain the initial ACME certificate.
 	// Defaults to 5 if zero.
 	MaxAttempts int
+
+	// Override certmagic's background renewal-check interval. Zero means use
+	// certmagic's default (10 minutes). Intended for the integration test
+	// that needs to observe a renewal moment within a few seconds; not
+	// useful as a production tuning knob.
+	RenewCheckInterval time.Duration
 }
 
 // TLSConfigSourceFromACME creates a TLSConfigSource that obtains certificates via ACME.
@@ -84,7 +90,7 @@ func TLSConfigSourceFromACME(acme *ACMEConfig) (TLSConfigSource, error) {
 		}
 	}
 
-	magicConfig := certmagic.NewDefault()
+	magicConfig := newCertmagicConfig(acme.RenewCheckInterval)
 
 	// Force an initial synchronous load of the certificate on startup,
 	// but retry with backoff instead of exiting the whole process. If no certificate
@@ -125,6 +131,24 @@ func TLSConfigSourceFromACME(acme *ACMEConfig) (TLSConfigSource, error) {
 	}
 
 	return newACMETLSConfigSource(magicConfig, acme)
+}
+
+// newCertmagicConfig builds a certmagic.Config. If renewCheckInterval > 0,
+// it creates a fresh Cache with that interval; otherwise it uses
+// certmagic.NewDefault() and the package singleton cache (production path).
+func newCertmagicConfig(renewCheckInterval time.Duration) *certmagic.Config {
+	if renewCheckInterval <= 0 {
+		return certmagic.NewDefault()
+	}
+	var cache *certmagic.Cache
+	cache = certmagic.NewCache(certmagic.CacheOptions{
+		GetConfigForCert: func(certmagic.Certificate) (*certmagic.Config, error) {
+			return certmagic.New(cache, certmagic.Default), nil
+		},
+		RenewCheckInterval: renewCheckInterval,
+		Logger:             certmagic.Default.Logger,
+	})
+	return certmagic.New(cache, certmagic.Default)
 }
 
 func newACMETLSConfigSource(magicConfig *certmagic.Config, acme *ACMEConfig) (*acmeTLSConfigSource, error) {

--- a/certloader/acmetlsconfig.go
+++ b/certloader/acmetlsconfig.go
@@ -53,6 +53,12 @@ type ACMEConfig struct {
 	// that needs to observe a renewal moment within a few seconds; not
 	// useful as a production tuning knob.
 	RenewCheckInterval time.Duration
+
+	// Override the port certmagic binds for TLS-ALPN-01 during initial
+	// issuance. Zero means use 443 (the RFC 8737 port). Intended for the
+	// integration test so it can run without privileged-port binding;
+	// production deployments should leave this unset.
+	AltTLSALPNPort int
 }
 
 // TLSConfigSourceFromACME creates a TLSConfigSource that obtains certificates via ACME.
@@ -60,6 +66,7 @@ func TLSConfigSourceFromACME(acme *ACMEConfig) (TLSConfigSource, error) {
 	certmagic.DefaultACME.DisableHTTPChallenge = true
 	certmagic.DefaultACME.Agreed = acme.TOSAgreed
 	certmagic.DefaultACME.Email = acme.Email
+	certmagic.DefaultACME.AltTLSALPNPort = acme.AltTLSALPNPort
 
 	// certmagic uses its ACMEManager.CA value as the CA to use for obtaining
 	// certs. If the desired goal is for ghostunnel to use the ACME CAs test

--- a/certloader/acmetlsconfig_test.go
+++ b/certloader/acmetlsconfig_test.go
@@ -332,6 +332,90 @@ func TestACMETLSConfigSourceReloadTrustStore(t *testing.T) {
 		"server config should no longer return the old system trust store")
 }
 
+func TestACMETLSConfigRelaxesClientAuthForACMEChallenge(t *testing.T) {
+	// Regression: with mTLS (RequireAndVerifyClientCert) on the base config,
+	// the TLS-ALPN-01 renewal probe presents no client cert and the handshake
+	// aborts, causing silent renewal failure. GetConfigForClient must return a
+	// per-connection config with ClientAuth=NoClientCert *only* for handshakes
+	// whose ALPN is exactly ["acme-tls/1"] (per RFC 8737), and nil (i.e.
+	// inherit the base mTLS config) for every other connection.
+	source := &acmeTLSConfigSource{
+		magicConfig:  certmagic.NewDefault(),
+		gtACMEConfig: &ACMEConfig{},
+	}
+
+	base := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+
+	serverConfig, err := source.GetServerConfig(base)
+	require.NoError(t, err)
+
+	tlsConfig := serverConfig.GetServerConfig()
+	require.NotNil(t, tlsConfig.GetConfigForClient, "GetConfigForClient must be installed")
+	assert.Equal(t, tls.RequireAndVerifyClientCert, tlsConfig.ClientAuth,
+		"base ClientAuth must still require client cert for real clients")
+
+	// ACME validator handshake: SNI set, ALPN exactly ["acme-tls/1"], no cert.
+	acmeHello := &tls.ClientHelloInfo{
+		ServerName:      "test.example.com",
+		SupportedProtos: []string{acmez.ACMETLS1Protocol},
+	}
+	relaxed, err := tlsConfig.GetConfigForClient(acmeHello)
+	require.NoError(t, err)
+	require.NotNil(t, relaxed, "GetConfigForClient must return a per-conn config for acme-tls/1")
+	assert.Equal(t, tls.NoClientCert, relaxed.ClientAuth,
+		"ClientAuth must be relaxed for acme-tls/1 probes")
+	assert.Nil(t, relaxed.ClientCAs, "ClientCAs must be cleared for acme-tls/1 probes")
+	assert.NotNil(t, relaxed.GetCertificate, "GetCertificate must still be set so certmagic serves the challenge cert")
+	assert.Equal(t, []string{acmez.ACMETLS1Protocol}, relaxed.NextProtos,
+		"NextProtos must be restricted to acme-tls/1 on the relaxed config to prevent ALPN downgrade")
+	assert.True(t, relaxed.SessionTicketsDisabled,
+		"SessionTicketsDisabled must be true on the relaxed config to prevent ticket-based mTLS bypass")
+
+	// Empty-SNI probe: RFC 8737 requires the validator to set SNI; certmagic
+	// refuses to serve a challenge cert without it. Mirror that gate.
+	noSNIHello := &tls.ClientHelloInfo{SupportedProtos: []string{acmez.ACMETLS1Protocol}}
+	noSNI, err := tlsConfig.GetConfigForClient(noSNIHello)
+	require.NoError(t, err)
+	assert.Nil(t, noSNI, "GetConfigForClient must NOT relax for acme-tls/1 with empty SNI")
+
+	// Mixed-ALPN probe: a client offering acme-tls/1 alongside other protocols
+	// is not a conformant ACME validator. It must NOT trigger relaxation, or
+	// an attacker could bypass mTLS by tacking acme-tls/1 onto a normal client.
+	mixedHello := &tls.ClientHelloInfo{
+		ServerName:      "test.example.com",
+		SupportedProtos: []string{acmez.ACMETLS1Protocol, "h2"},
+	}
+	mixed, err := tlsConfig.GetConfigForClient(mixedHello)
+	require.NoError(t, err)
+	assert.Nil(t, mixed, "GetConfigForClient must NOT relax for mixed ALPN containing acme-tls/1 plus other protocols")
+
+	mixedHello2 := &tls.ClientHelloInfo{
+		ServerName:      "test.example.com",
+		SupportedProtos: []string{"h2", acmez.ACMETLS1Protocol},
+	}
+	mixed2, err := tlsConfig.GetConfigForClient(mixedHello2)
+	require.NoError(t, err)
+	assert.Nil(t, mixed2, "GetConfigForClient must NOT relax regardless of acme-tls/1 position in mixed ALPN")
+
+	// Real client handshake: any other ALPN (or none) must inherit the base.
+	realHello := &tls.ClientHelloInfo{
+		ServerName:      "test.example.com",
+		SupportedProtos: []string{"h2", "http/1.1"},
+	}
+	inherit, err := tlsConfig.GetConfigForClient(realHello)
+	require.NoError(t, err)
+	assert.Nil(t, inherit, "GetConfigForClient must return nil for non-ACME handshakes so the base mTLS config applies")
+
+	emptyHello := &tls.ClientHelloInfo{}
+	inherit2, err := tlsConfig.GetConfigForClient(emptyHello)
+	require.NoError(t, err)
+	assert.Nil(t, inherit2, "GetConfigForClient must return nil when no ALPN is advertised")
+}
+
 func TestACMETLSConfigGetServerConfigNilTrustStore(t *testing.T) {
 	// When trust store is nil, ClientCAs should be nil (no client cert verification)
 	source := &acmeTLSConfigSource{

--- a/docs/certificates/acme.md
+++ b/docs/certificates/acme.md
@@ -61,6 +61,34 @@ intervention or `--timed-reload` is needed for ACME certificates.
 If a valid certificate already exists locally, Ghostunnel loads it from cache
 on startup without contacting the CA.
 
+## Renewal Under mTLS
+
+Renewal works even when client certificate authentication is enabled with
+flags like `--allow-cn`, `--allow-ou`, or `--allow-dns-san`. To check that
+you control the domain, the ACME CA opens a TLS handshake to port 443 that
+advertises the `acme-tls/1` ALPN protocol and presents no client
+certificate. Ghostunnel lets that one handshake complete without requiring
+a client cert. Every other connection still needs a valid client cert as
+you configured.
+
+Several rules keep this exemption from turning into a way around mTLS:
+
+- The ClientHello must offer exactly `["acme-tls/1"]` as its ALPN list. A
+  client that offers `acme-tls/1` alongside another protocol such as `h2`
+  is treated as a normal client and must present a valid client cert.
+- The relaxed handshake pins ALPN to `acme-tls/1` and cannot fall back to a
+  different protocol.
+- TLS session resumption is disabled for the relaxed handshake. A ticket
+  issued during a renewal probe cannot be reused later by a real client to
+  skip mTLS.
+- After the handshake finishes, Ghostunnel checks which ALPN was
+  negotiated. Any connection on `acme-tls/1` is closed without dialing the
+  backend. The validator only reads the challenge certificate from the
+  handshake and never sends application data, so closing here keeps probe
+  traffic away from your backend without breaking renewal.
+
+There are no flags to configure this. It is always on when ACME is enabled.
+
 ## Revoking or Force-Renewing
 
 Certmagic handles renewal automatically, but if you need to force a renewal

--- a/docs/certificates/acme.md
+++ b/docs/certificates/acme.md
@@ -66,10 +66,9 @@ on startup without contacting the CA.
 Renewal works even when client certificate authentication is enabled with
 flags like `--allow-cn`, `--allow-ou`, or `--allow-dns-san`. To check that
 you control the domain, the ACME CA opens a TLS handshake to port 443 that
-advertises the `acme-tls/1` ALPN protocol and presents no client
-certificate. Ghostunnel lets that one handshake complete without requiring
-a client cert. Every other connection still needs a valid client cert as
-you configured.
+advertises the `acme-tls/1` ALPN protocol and presents no client cert. 
+Ghostunnel lets that one handshake complete without requiring a client cert.
+Every other connection still needs a valid client cert as configured.
 
 Several rules keep this exemption from turning into a way around mTLS:
 
@@ -77,15 +76,13 @@ Several rules keep this exemption from turning into a way around mTLS:
   client that offers `acme-tls/1` alongside another protocol such as `h2`
   is treated as a normal client and must present a valid client cert.
 - The relaxed handshake pins ALPN to `acme-tls/1` and cannot fall back to a
-  different protocol.
-- TLS session resumption is disabled for the relaxed handshake. A ticket
-  issued during a renewal probe cannot be reused later by a real client to
-  skip mTLS.
+  different protocol and TLS session resumption is disabled for the relaxed
+  handshake. A ticket issued during a renewal probe cannot be reused later
+  by a real client to skip mTLS.
 - After the handshake finishes, Ghostunnel checks which ALPN was
   negotiated. Any connection on `acme-tls/1` is closed without dialing the
   backend. The validator only reads the challenge certificate from the
-  handshake and never sends application data, so closing here keeps probe
-  traffic away from your backend without breaking renewal.
+  handshake and never sends application data.
 
 There are no flags to configure this. It is always on when ACME is enabled.
 

--- a/main.go
+++ b/main.go
@@ -94,6 +94,9 @@ var (
 	serverAutoACMEAgreedTOS   = serverCommand.Flag("auto-acme-agree-to-tos", "Agree to the Terms of Service of the ACME CA").Default("false").Bool()
 	serverAutoACMEProdCA      = serverCommand.Flag("auto-acme-ca", "Specify the URL to the ACME CA. Defaults to Let's Encrypt if not specified.").PlaceHolder("https://some-acme-ca.example.com/").String()
 	serverAutoACMETestCA      = serverCommand.Flag("auto-acme-testca", "Specify the URL to the ACME CA's Test/Staging environment. If set, all requests will go to this CA and --auto-acme-ca will be ignored.").PlaceHolder("https://testing.some-acme-ca.example.com/").String()
+	// Hidden: override certmagic's background renewal-check interval. Only
+	// used by the ACME integration test to observe renewal within seconds.
+	serverAutoACMERenewCheckInterval = serverCommand.Flag("auto-acme-renew-check-interval", "").Hidden().Duration()
 
 	// Client flags
 	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
@@ -1014,12 +1017,13 @@ func getTLSConfigSource(disableAuth bool) (certloader.TLSConfigSource, error) {
 	if *serverAutoACMEFQDN != "" {
 		logger.Printf("using ACME server as certificate source")
 		acmeConfig := certloader.ACMEConfig{
-			FQDN:         *serverAutoACMEFQDN,
-			Email:        *serverAutoACMEEmail,
-			TOSAgreed:    *serverAutoACMEAgreedTOS,
-			ProdCAURL:    *serverAutoACMEProdCA,
-			TestCAURL:    *serverAutoACMETestCA,
-			CABundlePath: *caBundlePath,
+			FQDN:               *serverAutoACMEFQDN,
+			Email:              *serverAutoACMEEmail,
+			TOSAgreed:          *serverAutoACMEAgreedTOS,
+			ProdCAURL:          *serverAutoACMEProdCA,
+			TestCAURL:          *serverAutoACMETestCA,
+			CABundlePath:       *caBundlePath,
+			RenewCheckInterval: *serverAutoACMERenewCheckInterval,
 		}
 		source, err := certloader.TLSConfigSourceFromACME(&acmeConfig)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -97,6 +97,10 @@ var (
 	// Hidden: override certmagic's background renewal-check interval. Only
 	// used by the ACME integration test to observe renewal within seconds.
 	serverAutoACMERenewCheckInterval = serverCommand.Flag("auto-acme-renew-check-interval", "").Hidden().Duration()
+	// Hidden: override the port certmagic binds for TLS-ALPN-01 during
+	// initial issuance. Production should use 443 so the public ACME CA can
+	// reach it; the integration test sets this so it can run without root.
+	serverAutoACMEAltTLSALPNPort = serverCommand.Flag("auto-acme-alt-tls-alpn-port", "").Hidden().Int()
 
 	// Client flags
 	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
@@ -1024,6 +1028,7 @@ func getTLSConfigSource(disableAuth bool) (certloader.TLSConfigSource, error) {
 			TestCAURL:          *serverAutoACMETestCA,
 			CABundlePath:       *caBundlePath,
 			RenewCheckInterval: *serverAutoACMERenewCheckInterval,
+			AltTLSALPNPort:     *serverAutoACMEAltTLSALPNPort,
 		}
 		source, err := certloader.TLSConfigSourceFromACME(&acmeConfig)
 		if err != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -343,6 +343,16 @@ func (p *Proxy) Accept() {
 				return
 			}
 
+			// TLS-ALPN-01 challenge probes complete the handshake to deliver
+			// the challenge certificate, but carry no application data and
+			// must never reach the backend. The handshake itself ran with
+			// ClientAuth relaxed (see certloader/acmetlsconfig.go); refusing
+			// to proxy ensures that relaxation cannot become an mTLS bypass.
+			if isACMEChallengeConn(conn) {
+				p.logConditional(LogConnections, "completed ACME TLS-ALPN-01 challenge from %s; not forwarding to backend", conn.RemoteAddr())
+				return
+			}
+
 			backend, err := p.Dial(ctx)
 			if err != nil {
 				p.logConditional(LogConnectionErrors, "error on dial: %s", err)
@@ -368,6 +378,19 @@ func (p *Proxy) Accept() {
 			p.fuse(conn, backend)
 		})
 	}
+}
+
+// isACMEChallengeConn reports whether the (already-handshaken) connection
+// negotiated the TLS-ALPN-01 challenge protocol from RFC 8737. Such a
+// connection is an ACME validator probe and must not be proxied to the
+// backend: the relaxed ClientAuth in certloader/acmetlsconfig.go is scoped
+// to making the handshake complete, not to authorizing application data.
+func isACMEChallengeConn(conn net.Conn) bool {
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return false
+	}
+	return tlsConn.ConnectionState().NegotiatedProtocol == "acme-tls/1"
 }
 
 // Force handshake. Handshake usually happens on first read/write, but we want

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -33,6 +33,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -538,6 +539,127 @@ func TestForceHandshakeNonTLSConn(t *testing.T) {
 	ctx := context.Background()
 	err = forceHandshake(ctx, conn)
 	assert.Nil(t, err, "forceHandshake should succeed for non-TLS conn")
+}
+
+func TestIsACMEChallengeConn(t *testing.T) {
+	// Non-TLS conn is never an ACME challenge.
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+	assert.False(t, isACMEChallengeConn(a), "plain net.Conn must not be classified as ACME")
+
+	// TLS conn with no negotiated protocol is not an ACME challenge.
+	tlsConn := tls.Client(a, &tls.Config{InsecureSkipVerify: true})
+	assert.False(t, isACMEChallengeConn(tlsConn), "TLS conn with empty NegotiatedProtocol must not be classified as ACME")
+}
+
+func TestACMEChallengeNotForwardedToBackend(t *testing.T) {
+	// End-to-end: a TLS-ALPN-01 probe (ALPN=acme-tls/1, no client cert)
+	// against a proxy whose listener config requires mTLS but relaxes for
+	// acme-tls/1 must complete the TLS handshake AND must NOT result in a
+	// backend dial. This is what prevents the renewal exemption from
+	// becoming an mTLS bypass into the backend.
+	cert, _ := selfSignedCert(t)
+
+	clientCAs := x509.NewCertPool()
+	// Empty pool — no real client cert would ever satisfy mTLS, which is
+	// what we want: the only way through is the acme-tls/1 exemption.
+
+	baseConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+		NextProtos:   []string{"acme-tls/1"},
+		MinVersion:   tls.VersionTLS12,
+	}
+	baseConfig.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+		if len(chi.SupportedProtos) == 1 && chi.SupportedProtos[0] == "acme-tls/1" {
+			c := baseConfig.Clone()
+			c.ClientAuth = tls.NoClientCert
+			c.ClientCAs = nil
+			c.NextProtos = []string{"acme-tls/1"}
+			c.SessionTicketsDisabled = true
+			c.ClientSessionCache = nil
+			return c, nil
+		}
+		return nil, nil
+	}
+
+	rawIncoming, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	incoming := tls.NewListener(rawIncoming, baseConfig)
+	defer incoming.Close()
+
+	// Backend listener: we assert it is NEVER reached during this test.
+	target, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	defer target.Close()
+
+	var backendHits int32
+	backendDone := make(chan struct{})
+	go func() {
+		defer close(backendDone)
+		conn, err := target.Accept()
+		if err != nil {
+			return
+		}
+		atomic.AddInt32(&backendHits, 1)
+		conn.Close()
+	}()
+
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", target.Addr().String())
+	}
+
+	p := proxyForTest(incoming, dialer)
+	go p.Accept()
+	defer p.Shutdown()
+
+	// Drive an ACME validator-shaped handshake: only acme-tls/1 in ALPN,
+	// no client certificate, skip server verification (self-signed).
+	clientConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"acme-tls/1"},
+		MinVersion:         tls.VersionTLS12,
+	}
+	tlsClient, err := tls.Dial("tcp", incoming.Addr().String(), clientConfig)
+	assert.Nil(t, err, "TLS-ALPN-01 probe handshake must succeed")
+	if err == nil {
+		assert.Equal(t, "acme-tls/1", tlsClient.ConnectionState().NegotiatedProtocol,
+			"server must negotiate acme-tls/1")
+		tlsClient.Close()
+	}
+
+	// Give the proxy a moment to (incorrectly) dial the backend if it would.
+	select {
+	case <-backendDone:
+		// Backend Accept returned — only legitimate if the listener was
+		// closed below, not because a connection arrived.
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&backendHits),
+		"backend MUST NOT receive any connection from an ACME TLS-ALPN-01 probe")
+
+	// Sanity check: a normal (non-ACME) client without a client cert must
+	// still be rejected at the handshake — i.e. mTLS for the real path is
+	// not weakened by the exemption.
+	plainConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
+		MinVersion:         tls.VersionTLS12,
+	}
+	plain, err := tls.Dial("tcp", incoming.Addr().String(), plainConfig)
+	if err == nil {
+		// Handshake might appear to succeed from client side until first I/O
+		// in some TLS versions; force it.
+		err = plain.Handshake()
+		plain.Close()
+	}
+	assert.Error(t, err, "non-ACME client without cert must fail mTLS handshake")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&backendHits),
+		"backend MUST still not be reached after rejected mTLS handshake")
 }
 
 func TestLogConnectionMessageDisabled(t *testing.T) {

--- a/tests/common.py
+++ b/tests/common.py
@@ -414,6 +414,118 @@ def check_keytool():
         print("keytool not available", file=sys.stderr)
         sys.exit(2)
 
+def require_pebble():
+    """Skip the test unless the Pebble ACME test server is available.
+
+    Pebble (https://github.com/letsencrypt/pebble) is Let's Encrypt's
+    mini-CA for local testing. We look for it on PATH; if absent, skip.
+    """
+    if not shutil.which('pebble'):
+        print("pebble (Let's Encrypt test ACME server) not available on PATH",
+              file=sys.stderr)
+        sys.exit(2)
+
+
+def start_pebble(work_dir, directory_port, mgmt_port, tls_alpn_port,
+                 cert_validity_seconds=7776000):
+    """Start a Pebble ACME server bound to the given ports.
+
+    work_dir                : writable directory for Pebble's config + key
+                              files
+    directory_port          : port for the ACME directory HTTPS endpoint
+    mgmt_port               : port for Pebble's management HTTP API
+    tls_alpn_port           : port Pebble will dial to perform TLS-ALPN-01
+                              validation (must be where ghostunnel listens)
+    cert_validity_seconds   : validity period of issued certs, in seconds.
+                              Default 90 days; tests that want a quick
+                              renewal can pass a small value (e.g. 30) to
+                              force certmagic to renew soon.
+
+    Returns (Popen handle, directory_url, ca_cert_path).
+    The caller is responsible for terminate_pebble() in finally.
+    """
+    # Pebble needs its own self-signed cert for the directory endpoint.
+    # We use openssl to generate one. The CA cert path is returned so the
+    # ACME client (ghostunnel) can be told to trust it via PEBBLE_CA env
+    # var when launched (Go's crypto/x509 honors SSL_CERT_FILE).
+    pebble_key = os.path.join(work_dir, 'pebble.key')
+    pebble_crt = os.path.join(work_dir, 'pebble.crt')
+    check_call(
+        'openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 '
+        '-nodes -days 1 -subj /CN=pebble '
+        '-addext subjectAltName=DNS:localhost,IP:127.0.0.1 '
+        '-keyout {0} -out {1}'.format(pebble_key, pebble_crt),
+        shell=True, stdout=DEVNULL, stderr=DEVNULL)
+
+    config_path = os.path.join(work_dir, 'pebble-config.json')
+    config = {
+        "pebble": {
+            "listenAddress": "{0}:{1}".format(LOCALHOST, directory_port),
+            "managementListenAddress": "{0}:{1}".format(LOCALHOST, mgmt_port),
+            "certificate": pebble_crt,
+            "privateKey": pebble_key,
+            "httpPort": 80,  # unused (we run TLS-ALPN-01 only)
+            "tlsPort": tls_alpn_port,
+            "ocspResponderURL": "",
+            "externalAccountBindingRequired": False,
+            "profiles": {
+                "default": {
+                    "description": "ghostunnel integration test",
+                    "validityPeriod": int(cert_validity_seconds),
+                },
+            },
+        }
+    }
+    with open(config_path, 'w') as f:
+        json.dump(config, f)
+
+    env = os.environ.copy()
+    # Make validations deterministic: no random sleep, never reject valid
+    # challenges. We still want real TLS-ALPN-01 validation to happen.
+    env['PEBBLE_VA_NOSLEEP'] = '1'
+    env['PEBBLE_VA_ALWAYS_VALID'] = '0'
+    # Skip CAA checks; we have no DNS in tests.
+    env['PEBBLE_VA_NOCAACHECK'] = '1'
+
+    handle = Popen(
+        ['pebble', '-config', config_path, '-strict'],
+        stdout=sys.stderr.buffer, stderr=sys.stderr.buffer, env=env)
+
+    directory_url = 'https://{0}:{1}/dir'.format(LOCALHOST, directory_port)
+
+    # Poll the directory endpoint until it responds.
+    ctx = ssl.create_default_context(cafile=pebble_crt)
+    deadline = time.time() + 15
+    iteration = 0
+    while time.time() < deadline:
+        if handle.poll() is not None:
+            raise RuntimeError(
+                "pebble exited prematurely with code {0}".format(handle.returncode))
+        try:
+            urllib.request.urlopen(directory_url, context=ctx, timeout=2).read()
+            return handle, directory_url, pebble_crt
+        except Exception:
+            _poll_sleep(iteration)
+            iteration += 1
+    handle.terminate()
+    raise TimeoutError("pebble directory endpoint did not respond in time")
+
+
+def terminate_pebble(handle):
+    """Gracefully terminate Pebble. Best-effort: cleanup must not raise."""
+    if handle is None:
+        return
+    try:
+        handle.terminate()
+        try:
+            handle.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            handle.kill()
+    except OSError:
+        # Process already gone (race with natural exit). Nothing to clean up.
+        pass
+
+
 def require_platform(*platforms):
     """Skip the test unless running on one of the specified platforms.
 
@@ -431,13 +543,48 @@ def require_platform(*platforms):
     sys.exit(2)
 
 def require_admin():
-    """Skip the test (exit 2) unless running with Administrator privileges (Windows)."""
-    if not IS_WINDOWS:
+    """Skip the test (exit 2) unless running with Administrator/root privileges.
+
+    On POSIX, this means euid == 0 — needed e.g. to bind privileged ports.
+    On Windows, this calls into shell32 to check the admin token.
+    """
+    if IS_WINDOWS:
+        import ctypes
+        if not ctypes.windll.shell32.IsUserAnAdmin():
+            print("requires Administrator privileges, skipping", file=sys.stderr)
+            sys.exit(2)
         return
-    import ctypes
-    if not ctypes.windll.shell32.IsUserAnAdmin():
-        print("requires Administrator privileges, skipping", file=sys.stderr)
+    if os.geteuid() != 0:
+        print("requires root privileges, skipping", file=sys.stderr)
         sys.exit(2)
+
+
+def require_can_bind_privileged_port():
+    """Skip unless ghostunnel can bind a privileged (<1024) TCP port.
+
+    Either the test process must be root, or the ghostunnel coverage binary
+    must carry CAP_NET_BIND_SERVICE (Linux file capabilities). The capability
+    is not granted automatically; an operator or CI image can apply it via
+    `setcap cap_net_bind_service=+ep ghostunnel.cover` so the test runs
+    without root.
+    """
+    if IS_WINDOWS:
+        # Windows uses the admin token model; defer to require_admin.
+        require_admin()
+        return
+    if os.geteuid() == 0:
+        return
+    if platform.system() == 'Linux' and shutil.which('getcap'):
+        try:
+            out = check_output(['getcap', _GHOSTUNNEL_BINARY],
+                               stderr=DEVNULL).decode()
+            if 'cap_net_bind_service' in out.lower():
+                return
+        except subprocess.CalledProcessError:
+            pass
+    print("requires root or CAP_NET_BIND_SERVICE on the ghostunnel binary, "
+          "skipping", file=sys.stderr)
+    sys.exit(2)
 
 def reload_args():
     """Extra args to enable certificate reload on Windows via --timed-reload."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -486,6 +486,10 @@ def start_pebble(work_dir, directory_port, mgmt_port, tls_alpn_port,
     env['PEBBLE_VA_ALWAYS_VALID'] = '0'
     # Skip CAA checks; we have no DNS in tests.
     env['PEBBLE_VA_NOCAACHECK'] = '1'
+    # Force a fresh TLS-ALPN-01 challenge on every renewal. Pebble's
+    # default re-uses a still-valid authz 50% of the time, which would
+    # let a renewal succeed without actually dialing the listener.
+    env['PEBBLE_AUTHZREUSE'] = '0'
 
     handle = Popen(
         ['pebble', '-config', config_path, '-strict'],

--- a/tests/common.py
+++ b/tests/common.py
@@ -563,33 +563,6 @@ def require_admin():
         sys.exit(2)
 
 
-def require_can_bind_privileged_port():
-    """Skip unless ghostunnel can bind a privileged (<1024) TCP port.
-
-    Either the test process must be root, or the ghostunnel coverage binary
-    must carry CAP_NET_BIND_SERVICE (Linux file capabilities). The capability
-    is not granted automatically; an operator or CI image can apply it via
-    `setcap cap_net_bind_service=+ep ghostunnel.cover` so the test runs
-    without root.
-    """
-    if IS_WINDOWS:
-        # Windows uses the admin token model; defer to require_admin.
-        require_admin()
-        return
-    if os.geteuid() == 0:
-        return
-    if platform.system() == 'Linux' and shutil.which('getcap'):
-        try:
-            out = check_output(['getcap', _GHOSTUNNEL_BINARY],
-                               stderr=DEVNULL).decode()
-            if 'cap_net_bind_service' in out.lower():
-                return
-        except subprocess.CalledProcessError:
-            pass
-    print("requires root or CAP_NET_BIND_SERVICE on the ghostunnel binary, "
-          "skipping", file=sys.stderr)
-    sys.exit(2)
-
 def reload_args():
     """Extra args to enable certificate reload on Windows via --timed-reload."""
     return ['--timed-reload=1s'] if IS_WINDOWS else []

--- a/tests/test-server-acme-tls-alpn-renewal.py
+++ b/tests/test-server-acme-tls-alpn-renewal.py
@@ -43,8 +43,7 @@ The test asserts:
   3. A real mTLS client (no acme-tls/1 ALPN, valid client cert) is still
      proxied normally throughout.
 
-Skips if pebble is not on PATH or if the test process can't bind port 443
-(needs root or CAP_NET_BIND_SERVICE on the ghostunnel binary).
+Skips if not on Linux, or if pebble is not on PATH.
 """
 
 import hashlib
@@ -61,7 +60,6 @@ from common import (
     RootCert,
     get_free_port,
     print_ok,
-    require_can_bind_privileged_port,
     require_platform,
     require_pebble,
     run_ghostunnel,
@@ -104,13 +102,17 @@ def wait_for_ghostunnel_listener(port, client_cert, timeout=60):
 FQDN = 'localhost'  # Pebble validates against the SNI/identifier; localhost
                     # resolves on every test platform.
 
-# certmagic's internal TLS-ALPN-01 listener defaults to port 443
-# (ACMEIssuer.AltTLSALPNPort=0). For initial issuance to succeed, Pebble must
-# dial 443 *and* certmagic must be allowed to bind it. After issuance,
-# ghostunnel itself binds 443 for the main listener, where the renewal probe
-# shape is exercised. The bind requires either root or CAP_NET_BIND_SERVICE
-# on the ghostunnel binary; require_can_bind_privileged_port gates on that.
-ACME_PORT = 443
+# Production deployments use port 443 because that's where the public ACME CA
+# (Let's Encrypt) dials. For testing we steer Pebble, ghostunnel, and
+# certmagic's initial-issuance listener all at the same high port so the test
+# doesn't need root or CAP_NET_BIND_SERVICE. The override on the certmagic
+# side comes from the hidden --auto-acme-alt-tls-alpn-port flag below.
+#
+# release=True closes the SO_REUSEPORT reservation socket: certmagic's
+# initial-issuance listener (Go default, no SO_REUSEPORT) cannot co-bind a
+# held port on macOS. The brief race window before the real binder claims
+# the port is acceptable for this single-instance test.
+ACME_PORT = get_free_port(release=True)
 
 # Force a fast renewal cycle. Pebble issues 30-second certs; certmagic's
 # renewal threshold (RenewalWindowRatio=1/3) fires when ~10s remain, i.e.
@@ -130,6 +132,11 @@ class BackendListener:
     def __init__(self, port):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Co-bind with common.get_free_port's reservation socket (which has
+        # SO_REUSEPORT) — macOS requires every member of the pool to opt in.
+        reuseport = getattr(socket, 'SO_REUSEPORT', None)
+        if reuseport is not None:
+            self.sock.setsockopt(socket.SOL_SOCKET, reuseport, 1)
         self.sock.bind((LOCALHOST, port))
         self.sock.listen(8)
         self.accepted = 0
@@ -248,17 +255,16 @@ backend = None
 work_dir = tempfile.mkdtemp(prefix='ghostunnel-acme-test-')
 
 try:
-    # This test relies on a long-running TLS listener for Pebble to dial
-    # into for TLS-ALPN-01 validation. The mechanics work on Linux/macOS;
-    # skip Windows because Pebble's Windows story is poorly tested.
-    require_platform('Linux', 'Darwin')
+    # Linux only: macOS would need Pebble's self-signed directory cert
+    # added to the system keychain (Go's cgo-enabled x509 doesn't consult
+    # SSL_CERT_FILE on darwin); Windows lacks a tested Pebble path.
+    require_platform('Linux')
     require_pebble()
-    # Port 443 is privileged: either we're root, or the ghostunnel binary has
-    # CAP_NET_BIND_SERVICE.
-    require_can_bind_privileged_port()
 
-    pebble_directory_port = get_free_port()
-    pebble_mgmt_port = get_free_port()
+    # release=True drops the SO_REUSEPORT reservation socket: Pebble (Go
+    # default, no SO_REUSEPORT) cannot co-bind a held port on macOS.
+    pebble_directory_port = get_free_port(release=True)
+    pebble_mgmt_port = get_free_port(release=True)
 
     # Issue the test client cert from a separate root — this verifies that
     # the ACME-issued server cert and the mTLS client cert come from
@@ -266,7 +272,7 @@ try:
     client_root = RootCert('client-root')
     client_root.create_signed_cert('client')
 
-    # Start Pebble; it will dial back to ACME_PORT (443) to run TLS-ALPN-01
+    # Start Pebble; it will dial back to ACME_PORT to run TLS-ALPN-01
     # validation. Issue short-lived certs so certmagic decides to renew
     # within seconds.
     pebble, directory_url, pebble_ca = start_pebble(
@@ -295,6 +301,10 @@ try:
         '--auto-acme-agree-to-tos',
         '--auto-acme-ca={0}'.format(directory_url),
         '--auto-acme-renew-check-interval={0}'.format(RENEW_CHECK_INTERVAL),
+        # Tell certmagic to bind ACME_PORT (a free high port) for its
+        # TLS-ALPN-01 listener during initial issuance, matching where Pebble
+        # dials. Without this, certmagic would try to bind 443.
+        '--auto-acme-alt-tls-alpn-port={0}'.format(ACME_PORT),
         '--cacert={0}.crt'.format(client_root.name),
         '--allow-cn=client',
         # Pin TLS 1.2: under TLS 1.3 Go's client Handshake() returns

--- a/tests/test-server-acme-tls-alpn-renewal.py
+++ b/tests/test-server-acme-tls-alpn-renewal.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+Integration test for ACME TLS-ALPN-01 renewal under mTLS.
+
+Bug: ghostunnel's mTLS default sets ClientAuth=RequireAndVerifyClientCert
+on the main listener. The TLS-ALPN-01 renewal probe sends no client cert,
+so before the fix the renewal handshake aborted and the cert silently
+expired.
+
+To make the renewal path observable in a test we force the timing:
+
+  * Pebble issues certs with a 30-second validity period.
+  * Ghostunnel runs with --auto-acme-renew-check-interval=1s (hidden flag,
+    test-only), so certmagic's background maintenance loop wakes up every
+    second instead of every 10 minutes.
+
+certmagic computes "needs renewal" against RenewalWindowRatio (default
+1/3), so for a 30-second cert it tries to renew once roughly 10 seconds
+remain. That renewal happens while ghostunnel's main listener already owns
+port 443; certmagic's solver can't bind it (robustTryListen falls through
+with nil/nil), stashes the challenge cert in its in-memory map, and trusts
+the existing listener to serve it. Without the fix, ghostunnel's mTLS
+config rejects Pebble's no-cert probe and renewal fails. With the fix,
+the probe handshake completes, GetCertificate serves the challenge cert,
+Pebble validates, and a new cert is issued.
+
+The test asserts:
+  1. Ghostunnel obtains the initial cert (initial issuance via certmagic's
+     own internal listener — does NOT exercise the fix).
+  2. Ghostunnel performs a successful renewal while serving the main
+     listener — the cert's NotBefore advances. This DOES exercise the fix.
+  3. A real mTLS client (no acme-tls/1 ALPN, valid client cert) is still
+     proxied normally throughout.
+
+Skips if pebble is not on PATH or if the test process can't bind port 443
+(needs root or CAP_NET_BIND_SERVICE on the ghostunnel binary).
+"""
+
+import hashlib
+import os
+import shutil
+import socket
+import ssl
+import tempfile
+import threading
+import time
+
+from common import (
+    LOCALHOST,
+    RootCert,
+    get_free_port,
+    print_ok,
+    require_can_bind_privileged_port,
+    require_platform,
+    require_pebble,
+    run_ghostunnel,
+    start_pebble,
+    terminate,
+    terminate_pebble,
+    TARGET_PORT,
+)
+
+
+def wait_for_ghostunnel_listener(port, client_cert, timeout=60):
+    """Poll until a valid mTLS handshake to (LOCALHOST, port) succeeds.
+
+    A bare TCP accept isn't enough: during initial issuance certmagic
+    binds the same port for its TLS-ALPN-01 challenge listener and then
+    releases it just before ghostunnel binds. A TCP-only probe can race
+    that handoff and "succeed" against certmagic's listener while
+    ghostunnel hasn't bound yet. By driving a real mTLS handshake with a
+    valid client cert and no ALPN, we accept only ghostunnel's main
+    listener: certmagic's challenge listener has no cert to serve for a
+    no-ALPN ClientHello (its GetCertificate only fires for acme-tls/1).
+    """
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        ok, _, conn_or_err = tls_probe(port, alpn=None, client_cert=client_cert)
+        if ok:
+            try:
+                conn_or_err.close()
+            except OSError:
+                # Cleanup only; nothing actionable if close fails here.
+                pass
+            return
+        last_err = conn_or_err
+        time.sleep(0.5)
+    raise TimeoutError(
+        "ghostunnel listener on port {0} not ready in {1}s "
+        "(last handshake error: {2})".format(port, timeout, last_err))
+
+FQDN = 'localhost'  # Pebble validates against the SNI/identifier; localhost
+                    # resolves on every test platform.
+
+# certmagic's internal TLS-ALPN-01 listener defaults to port 443
+# (ACMEIssuer.AltTLSALPNPort=0). For initial issuance to succeed, Pebble must
+# dial 443 *and* certmagic must be allowed to bind it. After issuance,
+# ghostunnel itself binds 443 for the main listener, where the renewal probe
+# shape is exercised. The bind requires either root or CAP_NET_BIND_SERVICE
+# on the ghostunnel binary; require_can_bind_privileged_port gates on that.
+ACME_PORT = 443
+
+# Force a fast renewal cycle. Pebble issues 30-second certs; certmagic's
+# renewal threshold (RenewalWindowRatio=1/3) fires when ~10s remain, i.e.
+# ~20s after issuance. We poll certmagic with a 1-second check interval
+# (hidden flag --auto-acme-renew-check-interval).
+CERT_VALIDITY_SECONDS = 30
+RENEW_CHECK_INTERVAL = '1s'
+RENEWAL_DEADLINE_SECONDS = 45
+
+
+class BackendListener:
+    """A target listener that records whether anything ever connected.
+
+    Used to assert that ACME probe traffic never reaches the backend.
+    """
+
+    def __init__(self, port):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((LOCALHOST, port))
+        self.sock.listen(8)
+        self.accepted = 0
+        self.received = b''
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        self.sock.settimeout(0.25)
+        while not self._stop.is_set():
+            try:
+                conn, _ = self.sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            self.accepted += 1
+            try:
+                conn.settimeout(2)
+                chunk = conn.recv(4096)
+                if chunk:
+                    self.received += chunk
+                    conn.sendall(chunk)  # echo for scenario 4
+            except OSError:
+                # Per-client I/O errors must not kill the listener thread.
+                pass
+            finally:
+                conn.close()
+
+    def reset_counters(self):
+        self.accepted = 0
+        self.received = b''
+
+    def close(self):
+        self._stop.set()
+        try:
+            self.sock.close()
+        except OSError:
+            # Best-effort teardown; nothing to do if the socket was already closed.
+            pass
+        self._thread.join(timeout=2)
+
+
+def tls_probe(server_port, alpn=None, client_cert=None):
+    """Open a TLS connection to the proxy.
+
+    alpn        : list of ALPN protocols to advertise, or None to omit the
+                  extension entirely
+    client_cert : base name of a cert pair ({name}.crt + {name}.key), or
+                  None for no client certificate
+
+    Returns (handshake_ok, negotiated_alpn_or_None, ssock_or_error_str).
+    On success the caller owns the returned SSLSocket and must close it.
+    """
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    # Pin TLS 1.2 only. The test asserts handshake outcomes (e.g. "no-cert
+    # client rejected"); in TLS 1.3 the client returns from wrap_socket
+    # before the server's CertificateRequired alert arrives, so a
+    # server-side rejection wouldn't surface until first I/O. Forcing 1.2
+    # makes the handshake fully synchronous, so wrap_socket raises iff the
+    # server rejected. (Silences a CodeQL alert as a bonus.)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    if alpn:
+        ctx.set_alpn_protocols(alpn)
+    if client_cert is not None:
+        ctx.load_cert_chain(certfile=client_cert + '.crt',
+                            keyfile=client_cert + '.key')
+    try:
+        sock = socket.create_connection((LOCALHOST, server_port), timeout=5)
+    except OSError as e:
+        # No listener yet (or it just closed). Treat as a failed probe.
+        return False, None, str(e)
+    try:
+        wrapped = ctx.wrap_socket(sock, server_hostname=FQDN)
+    except (ssl.SSLError, OSError) as e:
+        try:
+            sock.close()
+        except OSError:
+            # Socket may already be half-closed by the failing handshake;
+            # any close error is uninteresting because we're returning the
+            # original handshake error to the caller.
+            pass
+        return False, None, str(e)
+    return True, wrapped.selected_alpn_protocol(), wrapped
+
+
+def fetch_server_cert_fingerprint(port, client_cert):
+    """Open a valid mTLS connection and return sha256(server_cert_der) hex.
+
+    Used to detect cert rotation across a renewal — the server's leaf cert
+    only changes when certmagic obtains a new one. The client cert is
+    required because the listener enforces mTLS; without one we can't
+    complete the handshake and thus can't read the peer cert from Python.
+    """
+    ok, _, conn = tls_probe(port, alpn=None, client_cert=client_cert)
+    if not ok:
+        raise RuntimeError("could not fetch server cert: {0}".format(conn))
+    try:
+        der = conn.getpeercert(binary_form=True)
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            # Already torn down by either side; nothing to report.
+            pass
+    return hashlib.sha256(der).hexdigest()
+
+
+pebble = None
+ghostunnel = None
+backend = None
+work_dir = tempfile.mkdtemp(prefix='ghostunnel-acme-test-')
+
+try:
+    # This test relies on a long-running TLS listener for Pebble to dial
+    # into for TLS-ALPN-01 validation. The mechanics work on Linux/macOS;
+    # skip Windows because Pebble's Windows story is poorly tested.
+    require_platform('Linux', 'Darwin')
+    require_pebble()
+    # Port 443 is privileged: either we're root, or the ghostunnel binary has
+    # CAP_NET_BIND_SERVICE.
+    require_can_bind_privileged_port()
+
+    pebble_directory_port = get_free_port()
+    pebble_mgmt_port = get_free_port()
+
+    # Issue the test client cert from a separate root — this verifies that
+    # the ACME-issued server cert and the mTLS client cert come from
+    # *different* trust paths, which is the realistic deployment shape.
+    client_root = RootCert('client-root')
+    client_root.create_signed_cert('client')
+
+    # Start Pebble; it will dial back to ACME_PORT (443) to run TLS-ALPN-01
+    # validation. Issue short-lived certs so certmagic decides to renew
+    # within seconds.
+    pebble, directory_url, pebble_ca = start_pebble(
+        work_dir, pebble_directory_port, pebble_mgmt_port, ACME_PORT,
+        cert_validity_seconds=CERT_VALIDITY_SECONDS)
+    print_ok("pebble running at {0} (cert validity={1}s)".format(
+        directory_url, CERT_VALIDITY_SECONDS))
+
+    backend = BackendListener(TARGET_PORT)
+
+    # Start ghostunnel in ACME mode with mTLS enforced via --allow-cn.
+    # SSL_CERT_FILE makes Go trust Pebble's self-signed directory cert.
+    # XDG_DATA_HOME isolates certmagic's cert cache into the test work dir,
+    # so repeated runs don't pick up stale state from a prior CA.
+    certmagic_home = os.path.join(work_dir, 'certmagic')
+    os.makedirs(certmagic_home, exist_ok=True)
+    os.environ['SSL_CERT_FILE'] = pebble_ca
+    os.environ['XDG_DATA_HOME'] = certmagic_home
+
+    ghostunnel = run_ghostunnel([
+        'server',
+        '--listen={0}:{1}'.format(LOCALHOST, ACME_PORT),
+        '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
+        '--auto-acme-cert={0}'.format(FQDN),
+        '--auto-acme-email=test@example.com',
+        '--auto-acme-agree-to-tos',
+        '--auto-acme-ca={0}'.format(directory_url),
+        '--auto-acme-renew-check-interval={0}'.format(RENEW_CHECK_INTERVAL),
+        '--cacert={0}.crt'.format(client_root.name),
+        '--allow-cn=client',
+    ])
+
+    # Wait for ghostunnel's main listener to come up. We probe with a real
+    # mTLS handshake so we don't race certmagic's brief challenge-listener
+    # window during initial issuance.
+    wait_for_ghostunnel_listener(ACME_PORT, 'client', timeout=60)
+    print_ok("ghostunnel obtained initial ACME certificate and is listening")
+
+    # The readiness probe itself dialed the backend (real mTLS connection
+    # got proxied through). Give the backend's accept loop a moment to
+    # observe the close, then we can reset counters cleanly.
+    time.sleep(0.5)
+
+    # -----------------------------------------------------------------
+    # Pre-renewal sanity: mTLS works for valid client, rejects no-cert.
+    # We omit ALPN to avoid colliding with NextProtos=["acme-tls/1"];
+    # without ALPN the handshake reaches the cert exchange and mTLS
+    # gates there.
+    # -----------------------------------------------------------------
+    backend.reset_counters()
+    ok, _, err = tls_probe(ACME_PORT, alpn=None)
+    assert not ok, "no-cert client must be rejected at handshake"
+    time.sleep(0.2)
+    assert backend.accepted == 0, "no-cert handshake must not reach backend"
+
+    backend.reset_counters()
+    ok, _, conn = tls_probe(ACME_PORT, alpn=None, client_cert='client')
+    assert ok, "valid mTLS client handshake must succeed: {0}".format(conn)
+    try:
+        conn.sendall(b'pre-renewal-ping')
+        echoed = conn.recv(4096)
+    finally:
+        conn.close()
+    time.sleep(0.2)
+    assert backend.accepted >= 1, "valid mTLS client must reach backend"
+    assert echoed.startswith(b'pre-renewal-ping'), (
+        "expected backend echo, got {0!r}".format(echoed))
+    print_ok("pre-renewal mTLS sanity PASS")
+
+    initial_fpr = fetch_server_cert_fingerprint(ACME_PORT, 'client')
+    print_ok("initial server cert sha256={0}...".format(initial_fpr[:16]))
+
+    # -----------------------------------------------------------------
+    # The bug under test: renewal under mTLS.
+    #
+    # certmagic's background loop will wake up (every 1s thanks to the
+    # hidden flag), notice the cert is past its renewal threshold, and
+    # initiate a new ACME order. Because ghostunnel already owns port
+    # 443, certmagic's solver can't bind it; robustTryListen falls
+    # through with (nil, nil), stashes the challenge cert in
+    # activeChallenges, and trusts the existing listener to serve it.
+    #
+    # That existing listener is ghostunnel's main one, configured with
+    # ClientAuth=RequireAndVerifyClientCert. The fix is a
+    # GetConfigForClient callback that relaxes ClientAuth for an
+    # acme-tls/1 ClientHello. Without the fix, Pebble's probe is
+    # rejected at the handshake's CertificateRequest step and renewal
+    # silently fails — the test will then time out with the cert never
+    # rotating.
+    # -----------------------------------------------------------------
+    print_ok("waiting up to {0}s for cert rotation...".format(
+        RENEWAL_DEADLINE_SECONDS))
+    deadline = time.time() + RENEWAL_DEADLINE_SECONDS
+    rotated_fpr = initial_fpr
+    while time.time() < deadline:
+        time.sleep(2)
+        try:
+            rotated_fpr = fetch_server_cert_fingerprint(ACME_PORT, 'client')
+        except (RuntimeError, OSError):
+            # Listener may be momentarily unstable during the renewal.
+            continue
+        if rotated_fpr != initial_fpr:
+            break
+
+    assert rotated_fpr != initial_fpr, (
+        "BUG: server certificate did not rotate within {0}s — "
+        "TLS-ALPN-01 renewal under mTLS failed silently".format(
+            RENEWAL_DEADLINE_SECONDS))
+    print_ok("renewal-under-mTLS PASS: cert rotated to sha256={0}...".format(
+        rotated_fpr[:16]))
+
+    # -----------------------------------------------------------------
+    # Post-renewal sanity: mTLS still works after the renewal completes.
+    # -----------------------------------------------------------------
+    backend.reset_counters()
+    ok, _, conn = tls_probe(ACME_PORT, alpn=None, client_cert='client')
+    assert ok, "post-renewal mTLS handshake must succeed: {0}".format(conn)
+    try:
+        conn.sendall(b'post-renewal-ping')
+        echoed = conn.recv(4096)
+    finally:
+        conn.close()
+    assert echoed.startswith(b'post-renewal-ping'), (
+        "expected backend echo post-renewal, got {0!r}".format(echoed))
+    print_ok("post-renewal mTLS sanity PASS")
+
+finally:
+    terminate(ghostunnel)
+    terminate_pebble(pebble)
+    if backend is not None:
+        backend.close()
+    shutil.rmtree(work_dir, ignore_errors=True)

--- a/tests/test-server-acme-tls-alpn-renewal.py
+++ b/tests/test-server-acme-tls-alpn-renewal.py
@@ -7,12 +7,23 @@ on the main listener. The TLS-ALPN-01 renewal probe sends no client cert,
 so before the fix the renewal handshake aborted and the cert silently
 expired.
 
+The failure is only visible at the validator under TLS 1.2. In TLS 1.3
+the server validates the client cert *after* the client's Finished, so
+Go's tls.Conn.Handshake() returns success and Pebble (and Boulder)
+extract the challenge cert from ConnectionState before the server's
+"certificate required" alert arrives. To make the bug observable we pin
+the listener to --max-tls-version=TLS1.2 below, matching the worst-case
+peer.
+
 To make the renewal path observable in a test we force the timing:
 
   * Pebble issues certs with a 30-second validity period.
   * Ghostunnel runs with --auto-acme-renew-check-interval=1s (hidden flag,
     test-only), so certmagic's background maintenance loop wakes up every
     second instead of every 10 minutes.
+  * PEBBLE_AUTHZREUSE=0 (set in common.start_pebble) forces Pebble to
+    run a fresh TLS-ALPN-01 challenge on every renewal; the default 50%
+    reuse would silently skip the probe.
 
 certmagic computes "needs renewal" against RenewalWindowRatio (default
 1/3), so for a 30-second cert it tries to renew once roughly 10 seconds
@@ -286,6 +297,12 @@ try:
         '--auto-acme-renew-check-interval={0}'.format(RENEW_CHECK_INTERVAL),
         '--cacert={0}.crt'.format(client_root.name),
         '--allow-cn=client',
+        # Pin TLS 1.2: under TLS 1.3 Go's client Handshake() returns
+        # success before the server's client-cert rejection arrives, so
+        # Pebble would extract the challenge cert and the bug would be
+        # invisible. TLS 1.2 fails the handshake before ConnectionState
+        # is populated, exposing the bug.
+        '--max-tls-version=TLS1.2',
     ])
 
     # Wait for ghostunnel's main listener to come up. We probe with a real


### PR DESCRIPTION
The ACME TLS-ALPN-01 renewal probes can fail silently when Ghostunnel enforces mTLS, depending on validator behavior. As the validator presents no client cert, the handshake may fail without the validator getting the challenge cert. Exact behavior depends on TLS version. In practice, it seems to have worked previously as long as Boulder/Pebble used TLS 1.3 for the validation. Still, it's better to fix this explicitly and not rely on the particular behavior of the validator. 

Fix: Install `GetConfigForClient` on the ACME server config that relaxes `ClientAuth` to `NoClientCert` only for handshakes whose ALPN is exactly `["acme-tls/1"]` (per RFC 8737). The relaxed handshake forces `NextProtos=["acme-tls/1"]` and disables session resumption so the exemption cannot be turned into an mTLS bypass. In the proxy, we handle challenge connections and make sure we don't forward them to the backend. 