### PR TITLE
Reject --use-workload-api combined with file-based credential flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -412,24 +412,22 @@ func validateServerProxyProtocol() error {
 }
 
 func validateClientCredentials() error {
-	fileCredCount := validateCredentials([]bool{
+	// --disable-authentication is mutex with file-based identity flags, but
+	// may be combined with --use-workload-api for server verification only.
+	disableAuthCounts := *clientDisableAuth && !*useWorkloadAPI
+	count := validateCredentials([]bool{
 		*keystorePath != "",
 		hasKeychainIdentity(),
 		(*certPath != "" && *keyPath != ""),
 		(*certPath != "" && hasPKCS11()),
+		*useWorkloadAPI,
+		disableAuthCounts,
 	})
-	if *useWorkloadAPI && fileCredCount > 0 {
-		return errors.New("--use-workload-api is mutually exclusive with --keystore, --cert/--key, and --keychain-identity/issuer")
-	}
-	count := fileCredCount
-	if *clientDisableAuth {
-		count++
-	}
-	if count == 0 && !*useWorkloadAPI {
+	if count == 0 {
 		return errors.New("at least one of --keystore, --cert/--key, --keychain-identity/issuer (if supported), --use-workload-api or --disable-authentication flags is required")
 	}
 	if count > 1 {
-		return errors.New("--keystore, --cert/--key, --keychain-identity/issuer and --disable-authentication flags are mutually exclusive")
+		return errors.New("--keystore, --cert/--key, --keychain-identity/issuer, --use-workload-api and --disable-authentication flags are mutually exclusive")
 	}
 	return validateCertKeyPair()
 }

--- a/main.go
+++ b/main.go
@@ -412,15 +412,21 @@ func validateServerProxyProtocol() error {
 }
 
 func validateClientCredentials() error {
-	count := validateCredentials([]bool{
+	fileCredCount := validateCredentials([]bool{
 		*keystorePath != "",
 		hasKeychainIdentity(),
 		(*certPath != "" && *keyPath != ""),
 		(*certPath != "" && hasPKCS11()),
-		*clientDisableAuth,
 	})
+	if *useWorkloadAPI && fileCredCount > 0 {
+		return errors.New("--use-workload-api is mutually exclusive with --keystore, --cert/--key, and --keychain-identity/issuer")
+	}
+	count := fileCredCount
+	if *clientDisableAuth {
+		count++
+	}
 	if count == 0 && !*useWorkloadAPI {
-		return errors.New("at least one of --keystore, --cert/--key, --keychain-identity/issuer (if supported) or --disable-authentication flags is required")
+		return errors.New("at least one of --keystore, --cert/--key, --keychain-identity/issuer (if supported), --use-workload-api or --disable-authentication flags is required")
 	}
 	if count > 1 {
 		return errors.New("--keystore, --cert/--key, --keychain-identity/issuer and --disable-authentication flags are mutually exclusive")

--- a/tests/test-mutually-exclusive-client-flags.py
+++ b/tests/test-mutually-exclusive-client-flags.py
@@ -7,6 +7,7 @@ ghostunnel2 = None
 ghostunnel3 = None
 ghostunnel4 = None
 ghostunnel5 = None
+ghostunnel6 = None
 try:
     # create certs
     root = RootCert('root')
@@ -52,9 +53,18 @@ try:
                                   '--cert=server.key',
                                   '--cacert=root.crt'])
     assert_not_zero(ghostunnel5)
+
+    ghostunnel6 = run_ghostunnel(['client',
+                                  '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+                                  '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
+                                  '--use-workload-api',
+                                  '--keystore=server.p12',
+                                  '--cacert=root.crt'])
+    assert_not_zero(ghostunnel6)
 finally:
     terminate(ghostunnel1)
     terminate(ghostunnel2)
     terminate(ghostunnel3)
     terminate(ghostunnel4)
     terminate(ghostunnel5)
+    terminate(ghostunnel6)


### PR DESCRIPTION
Reject --use-workload-api combined with file-based credential flags: these can't be used together. Note that this flag *can* be used with disable-authentication however (the workload API can be used to give a CA bundle, it's not only for the client cert).