### PR TITLE
Fix client mode unlinking systemd/launchd-managed UNIX socket

### DIFF
--- a/main.go
+++ b/main.go
@@ -768,11 +768,6 @@ func clientListen(env *Environment) error {
 		return err
 	}
 
-	// If this is a UNIX socket, make sure we cleanup files on close.
-	if ul, ok := listener.(*net.UnixListener); ok {
-		ul.SetUnlinkOnClose(true)
-	}
-
 	p := proxy.New(
 		listener,
 		*connectTimeout,

--- a/socket/net_test.go
+++ b/socket/net_test.go
@@ -17,6 +17,7 @@
 package socket
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -121,6 +122,36 @@ func TestOpenUnixSocket(t *testing.T) {
 	assert.Nil(t, err, "should be able to open Unix socket")
 	defer func() { _ = ln.Close() }()
 	assert.NotNil(t, ln.Addr(), "listener should have an address")
+}
+
+// TestOpenUnixSocketUnlinksOnClose pins down the contract that callers
+// (clientListen, serverListen) rely on: when Open creates a UNIX socket on
+// behalf of ghostunnel, it owns the path and unlinks it on Close. If this
+// guarantee is removed, the redundant cleanup that used to live in
+// clientListen would need to be restored.
+func TestOpenUnixSocketUnlinksOnClose(t *testing.T) {
+	// Use a short tmpdir to stay under macOS's 104-char sun_path limit.
+	tmpDir, err := os.MkdirTemp("", "gs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "test.sock")
+
+	ln, err := Open("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("socket should exist after Open: %v", err)
+	}
+
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(sockPath)
+	assert.True(t, os.IsNotExist(err), "socket should be unlinked after Close, but got: %v", err)
 }
 
 func TestOpenUnixSocketListenError(t *testing.T) {

--- a/socket/systemd_test.go
+++ b/socket/systemd_test.go
@@ -4,6 +4,8 @@ package socket
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +57,54 @@ func TestSystemdSocketMultipleSocketsSameName(t *testing.T) {
 
 	_, err = systemdSocketFromMap("web", listeners)
 	assert.NotNil(t, err, "should fail when a name has multiple sockets")
+}
+
+// TestSystemdInheritedUnixSocketNotUnlinkedOnClose documents the contract that
+// clientListen/serverListen rely on: a UNIX listener inherited from systemd
+// (built via net.FileListener, as activation.ListenersWithNames does
+// internally) must not unlink the socket path on Close. The service manager
+// owns the path and may recreate the listener across exec restarts; unlinking
+// it from the child breaks that handoff and destroys the unit's SocketUser /
+// SocketGroup / SocketMode settings.
+func TestSystemdInheritedUnixSocketNotUnlinkedOnClose(t *testing.T) {
+	// Short tmpdir keeps the path under the AF_UNIX sun_path limit.
+	tmpDir, err := os.MkdirTemp("", "gs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "test.sock")
+
+	// Mimic systemd's setup: an outer process binds the socket and would not
+	// unlink it on its own exit.
+	parent, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent.(*net.UnixListener).SetUnlinkOnClose(false)
+	defer parent.Close()
+
+	f, err := parent.(*net.UnixListener).File()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// activation.ListenersWithNames produces child listeners exactly this way.
+	inherited, err := net.FileListener(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := systemdSocketFromMap("test", map[string][]net.Listener{
+		"test": {inherited},
+	})
+	assert.Nil(t, err)
+
+	// Closing the inherited listener (as graceful shutdown does) must leave
+	// the path in place.
+	assert.Nil(t, result.Close())
+
+	_, err = os.Stat(sockPath)
+	assert.NoError(t, err, "systemd-inherited UNIX socket must not be unlinked on Close")
 }

--- a/tests/test-client-systemd-unix-socket-persists.py
+++ b/tests/test-client-systemd-unix-socket-persists.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+"""
+Regression test: with --listen=systemd:NAME pointing at a UNIX socket,
+ghostunnel must NOT unlink the socket path on shutdown. The service manager
+owns the path; deleting it from the child destroys the unit's SocketUser /
+SocketGroup / SocketMode settings and breaks handoff across exec restarts.
+
+This test emulates the service-manager handoff directly: this Python process
+binds the UNIX socket and keeps the listener FD open for the duration of the
+test. If sock_path goes missing after ghostunnel exits, it can only be
+because ghostunnel itself unlinked it.
+"""
+
+import os
+import shutil
+import socket as pysocket
+import subprocess
+import tempfile
+import time
+from common import LOCALHOST, RootCert, print_ok, require_platform, _GHOSTUNNEL_BINARY, _COVERAGE_DIR
+
+require_platform('Linux')
+
+# Short tmpdir to stay under AF_UNIX's sun_path length limit.
+sock_dir = tempfile.mkdtemp(prefix='gt-')
+sock_path = os.path.join(sock_dir, 'client.sock')
+
+ghostunnel = None
+unix_sock = None
+
+try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('client')
+
+    # Bind the UNIX socket exactly as a service manager would.
+    unix_sock = pysocket.socket(pysocket.AF_UNIX, pysocket.SOCK_STREAM)
+    unix_sock.bind(sock_path)
+    unix_sock.listen()
+
+    # Coverage env mirrors run_ghostunnel().
+    env = os.environ.copy()
+    integration_coverdir = os.path.join(_COVERAGE_DIR, 'integration')
+    os.makedirs(integration_coverdir, exist_ok=True)
+    env['GOCOVERDIR'] = integration_coverdir
+    env['LISTEN_FDS'] = '1'
+    env['LISTEN_FDNAMES'] = 'client'
+
+    # systemd's protocol expects the inherited FD at position 3. Python's
+    # pass_fds preserves the parent's FD numbers, so dup the socket into
+    # position 3 inside the child via preexec_fn. LISTEN_PID must equal the
+    # child's PID, so a shell prologue sets it post-fork and execs ghostunnel
+    # (preserving the PID).
+    sock_fd = unix_sock.fileno()
+
+    def position_fd():
+        os.dup2(sock_fd, 3)
+
+    cmd = [
+        'sh', '-c', 'export LISTEN_PID=$$; exec "$@"', '--',
+        _GHOSTUNNEL_BINARY,
+        'client',
+        '--listen=systemd:client',
+        # Target is never connected to — we only exercise startup + shutdown.
+        '--target={0}:9'.format(LOCALHOST),
+        '--keystore=client.p12',
+        '--cacert=root.crt',
+        '--shutdown-timeout=1s',
+        '--close-timeout=1s',
+    ]
+    print_ok('running: ' + ' '.join(cmd))
+    ghostunnel = subprocess.Popen(
+        cmd, env=env, preexec_fn=position_fd, pass_fds=(3,))
+
+    # Give ghostunnel a moment to wire up its listener.
+    time.sleep(2)
+    if ghostunnel.poll() is not None:
+        raise Exception(
+            'ghostunnel exited prematurely with code {0}'.format(ghostunnel.returncode))
+
+    # SIGTERM and wait for graceful shutdown.
+    ghostunnel.terminate()
+    ghostunnel.wait(timeout=10)
+
+    # Python still holds unix_sock open. The path can only be missing if
+    # ghostunnel explicitly unlinked it — which is the bug under test.
+    if not os.path.exists(sock_path):
+        raise Exception(
+            'UNIX socket {0} was unlinked on ghostunnel shutdown'.format(sock_path))
+
+    print_ok('OK: systemd-managed UNIX socket persisted after termination')
+finally:
+    if ghostunnel and ghostunnel.poll() is None:
+        ghostunnel.kill()
+    if unix_sock:
+        unix_sock.close()
+    shutil.rmtree(sock_dir, ignore_errors=True)


### PR DESCRIPTION
The redundant `SetUnlinkOnClose(true)` in clientListen fired for any `net.UnixListener`, including ones inherited from systemd or launchd socket activation, causing the service manager's socket file to be deleted on shutdown. `socket.Open` already handles `unix:PATH` correctly.