### PR TITLE
Make temp dir for integration tests configurable

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -42,5 +42,9 @@ ENV SOFTHSM2_CONF=/etc/softhsm/softhsm2.conf
 # Add GOPATH/bin to PATH for mage (default GOPATH in golang images is /go)
 ENV PATH=$PATH:/go/bin
 
-ENTRYPOINT ["mage"]
+# Redirect Python test fixtures (cert work dir, unix socket parents) out of
+# /tmp at container start so we exercise ghostunnel's per-address landlock
+# rules instead of riding on /tmp being in defaultReadWritePaths. A fresh
+# random dir per container run keeps repeated runs isolated.
+ENTRYPOINT ["sh", "-c", "export GHOSTUNNEL_TEST_TMPDIR=$(mktemp -d /var/ghostunnel-test-XXXXXX) && exec mage \"$@\"", "--"]
 CMD ["-v", "test:softhsmimport", "test:all"]

--- a/tests/common.py
+++ b/tests/common.py
@@ -89,8 +89,20 @@ STATUS_PORT = get_free_port()
 LISTEN_PORT = get_free_port()
 TARGET_PORT = get_free_port()
 
+def _test_tmpdir():
+    """Override the default mkdtemp/mkstemp parent for fixtures.
+
+    GHOSTUNNEL_TEST_TMPDIR lets the test environment redirect cert
+    work dirs and unix-socket fixtures out of /tmp (which is in
+    ghostunnel's landlock defaultReadWritePaths and therefore masks
+    bugs in per-address rule installation). Unset: mkdtemp's default
+    ($TMPDIR or /tmp), matching historical behavior.
+    """
+    return os.environ.get('GHOSTUNNEL_TEST_TMPDIR') or None
+
+
 # Create a per-test temporary working directory for cert file isolation
-_WORK_DIR = mkdtemp(prefix='ghostunnel-test-')
+_WORK_DIR = mkdtemp(prefix='ghostunnel-test-', dir=_test_tmpdir())
 os.chdir(_WORK_DIR)
 
 
@@ -649,7 +661,7 @@ class TlsServer(MySocket):
 class UnixClient(MySocket):
     def __init__(self):
         super().__init__()
-        self.socket_path = os.path.join(mkdtemp(), 'ghostunnel-test-socket')
+        self.socket_path = os.path.join(mkdtemp(dir=_test_tmpdir()), 'ghostunnel-test-socket')
 
     def get_socket_path(self):
         return self.socket_path
@@ -679,7 +691,7 @@ class UnixClient(MySocket):
 class UnixServer(MySocket):
     def __init__(self):
         super().__init__()
-        self.socket_path = os.path.join(mkdtemp(), 'ghostunnel-test-socket')
+        self.socket_path = os.path.join(mkdtemp(dir=_test_tmpdir()), 'ghostunnel-test-socket')
         self.listening = False
         self.listener = None
 


### PR DESCRIPTION
Make temp dir for integration tests configurable, so we don't just write files to /tmp which is in the default landlock rules. This way the rule building gets exercised/tested in more depth. 