### PR TITLE
CI: Add FreeBSD test job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,18 +54,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Run integration tests in FreeBSD VM
+      - name: Run tests in FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
           release: '14.3'
           usesh: true
-          copyback: false
           prepare: |
             pkg install -y go python3
           run: |
             go version
             python3 --version
-            go tool mage -v test:integration
+            go tool mage -v test:all
+      - name: Codecov upload
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage/all.profile
+          flags: freebsd
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-docker:
     name: Tests (PKCS#11/SoftHSM)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,26 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       
+  test-freebsd:
+    name: Tests (FreeBSD)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run integration tests in FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: '14.3'
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y go python3
+          run: |
+            go version
+            python3 --version
+            go tool mage -v test:integration
+
   test-docker:
     name: Tests (PKCS#11/SoftHSM)
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run tests in FreeBSD VM
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1.4.6
         with:
           release: '14.3'
           usesh: true


### PR DESCRIPTION
## Summary
Add a new CI job to test Ghostunnel on FreeBSD 14.3 using the vmactions/freebsd-vm action, ensuring compatibility with the FreeBSD platform.

## Changes
- Added `test-freebsd` job to `.github/workflows/test.yml` that:
  - Runs on Ubuntu with a FreeBSD 14.3 VM via vmactions/freebsd-vm@v1
  - Installs Go and Python3 dependencies
  - Executes the full test suite (`go tool mage test:all`)
  - Uploads coverage results to Codecov with the `freebsd` flag
  - Skips Codecov upload for dependabot PRs (consistent with other test jobs)

## Implementation Details
The new job follows the same pattern as the existing Linux test job, including:
- Timeout of 60 minutes
- Codecov integration with proper token handling
- Conditional Codecov upload to exclude dependabot runs
- Verbose output for debugging

https://claude.ai/code/session_01JhZSy6SwKzNZoK4BPjvYcV