### PR TITLE
Fix: PROXY protocol over unix-socket behavior

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -115,13 +115,20 @@ const (
 )
 
 func transportProtocol(c net.Conn) proxyproto.AddressFamilyAndProtocol {
-	if addr, ok := c.RemoteAddr().(*net.TCPAddr); ok {
+	switch addr := c.RemoteAddr().(type) {
+	case *net.TCPAddr:
 		if addr.IP.To4() != nil {
 			return proxyproto.TCPv4
 		}
 		return proxyproto.TCPv6
+	case *net.UnixAddr:
+		// Unix-domain listeners are valid PROXY protocol carriers; without
+		// this case, go-proxyproto's formatVersion2 rejects the *net.UnixAddr
+		// SourceAddr/DestinationAddr as ErrInvalidAddress and every connection
+		// fails per-connection at WriteTo time.
+		return proxyproto.UnixStream
 	}
-	return proxyproto.TCPv4
+	return proxyproto.UNSPEC
 }
 
 func proxyProtoHeader(c net.Conn, tlsState *tls.ConnectionState, mode ProxyProtocolMode, logger Logger) *proxyproto.Header {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -33,6 +33,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1010,9 +1011,45 @@ func TestTransportProtocol(t *testing.T) {
 		assert.Equal(t, proxyproto.TCPv6, transportProtocol(conn))
 	})
 
-	t.Run("non-TCP fallback", func(t *testing.T) {
-		conn := &mockConn{} // RemoteAddr returns *net.IPAddr, not *net.TCPAddr
-		assert.Equal(t, proxyproto.TCPv4, transportProtocol(conn))
+	t.Run("Unix", func(t *testing.T) {
+		dir := t.TempDir()
+		sockPath := filepath.Join(dir, "s.sock")
+		ln, err := net.Listen("unix", sockPath)
+		assert.Nil(t, err)
+		defer ln.Close()
+
+		go func() {
+			c, _ := ln.Accept()
+			if c != nil {
+				c.Close()
+			}
+		}()
+
+		conn, err := net.Dial("unix", sockPath)
+		assert.Nil(t, err)
+		defer conn.Close()
+
+		assert.Equal(t, proxyproto.UnixStream, transportProtocol(conn))
+
+		// Regression check: when the listener is unix,
+		// proxyProtoHeader(...).WriteTo previously failed with
+		// proxyproto.ErrInvalidAddress because TransportProtocol was
+		// TCPv4 but SourceAddr/DestinationAddr were *net.UnixAddr, causing
+		// every proxied connection to be dropped before any bytes were
+		// written to the backend.
+		h := proxyProtoHeader(conn, nil, ProxyProtocolConn, &testLogger{})
+		var buf bytes.Buffer
+		n, err := h.WriteTo(&buf)
+		assert.Nil(t, err, "WriteTo must not return ErrInvalidAddress for unix listener")
+		assert.True(t, n > 0, "WriteTo must write the PROXY header bytes")
+	})
+
+	t.Run("unknown address fallback", func(t *testing.T) {
+		// RemoteAddr returns *net.IPAddr, which is neither *net.TCPAddr
+		// nor *net.UnixAddr; we fall back to UNSPEC rather than misreporting
+		// the transport protocol.
+		conn := &mockConn{}
+		assert.Equal(t, proxyproto.UNSPEC, transportProtocol(conn))
 	})
 }
 

--- a/tests/test-server-unix-socket-listener.py
+++ b/tests/test-server-unix-socket-listener.py
@@ -4,11 +4,11 @@
 Server-mode TLS termination on a unix-domain listener (--listen=unix:PATH).
 Two phases:
   1. Plain TLS-over-unix: handshake + bidirectional payload to a TCP backend.
-  2. With --proxy-protocol: pins down current behavior. The non-TCP fallback
-     in proxy.go transportProtocol claims TCPv4 while SourceAddr is a
-     UnixAddr, so proxyproto fails to format the header and the backend
-     sees EOF before any bytes. A future fix that emits a proper header
-     (AF_UNIX/AF_UNSPEC) or rejects at startup will flip the assertion.
+  2. With --proxy-protocol: the backend receives a PROXY protocol v2
+     header with the AF_UNIX/STREAM family byte, followed by the
+     forwarded payload. (Previously, transportProtocol claimed TCPv4
+     while SourceAddr was a UnixAddr, so proxyproto failed to format
+     the header and the backend saw EOF before any bytes.)
 """
 
 from common import LOCALHOST, RootCert, STATUS_PORT, TcpClient, \
@@ -128,8 +128,8 @@ def _run_plain_phase():
 
 
 def _run_proxy_protocol_phase():
-    """TLS-over-unix listener with --proxy-protocol. Backend should see EOF
-    before any PROXY header (current behavior: header-format failure)."""
+    """TLS-over-unix listener with --proxy-protocol. Backend should see a
+    PROXY v2 header (AF_UNIX/STREAM) followed by the forwarded payload."""
     print_ok("=== phase: unix listener + --proxy-protocol ===")
 
     tmpdir = mkdtemp(prefix='ghostunnel-unix-listener-')
@@ -168,44 +168,50 @@ def _run_proxy_protocol_phase():
         conn.settimeout(TIMEOUT)
         print_ok("backend accepted forwarded connection")
 
-        # Read up to 16 bytes (a complete v2 header needs 16+). Expect EOF first.
-        # A timeout here means ghostunnel did NOT close the backend — that's the
-        # regression we want to catch, so raise rather than silently breaking.
-        preamble = b''
-        while len(preamble) < 16:
-            try:
-                chunk = conn.recv(16 - len(preamble))
-            except (socket.timeout, TimeoutError) as e:
-                raise Exception(
-                    "backend read timed out before EOF; ghostunnel did not "
-                    "close the connection (regression): {0}".format(e))
-            if not chunk:
-                break
-            preamble += chunk
+        def recv_exact(n, what):
+            buf = b''
+            while len(buf) < n:
+                chunk = conn.recv(n - len(buf))
+                if not chunk:
+                    raise Exception(
+                        "backend saw EOF after {0} bytes while reading "
+                        "{1} (expected {2} bytes)".format(len(buf), what, n))
+                buf += chunk
+            return buf
 
-        # If a future change emits a real PROXY v2 header for unix peers,
-        # this fires and forces an explicit update to code and test.
-        if preamble[:12] == PP2_SIGNATURE:
-            fam = preamble[13] if len(preamble) > 13 else None
+        # Fixed 16-byte PROXY v2 preamble: 12-byte signature, then
+        # version/command, family/protocol, and address block length.
+        preamble = recv_exact(16, "PROXY v2 preamble")
+        if preamble[:12] != PP2_SIGNATURE:
             raise Exception(
-                "PROXY-protocol-over-unix now emits a v2 signature "
-                "(family/proto byte = {0!r}); update this test and "
-                "decide whether the new contract is correct.".format(fam))
-
-        if len(preamble) != 0:
+                "expected PROXY v2 signature, got {0!r}".format(
+                    preamble[:12]))
+        if preamble[12] != 0x21:
             raise Exception(
-                "expected backend to see EOF before any bytes when "
-                "--proxy-protocol is combined with a unix listener "
-                "(header-format failure), got {0} bytes: {1!r}".format(
-                    len(preamble), preamble))
-        print_ok("backend saw EOF (current --proxy-protocol+unix "
-                 "fallback closes the backend connection)")
+                "expected version 2 / PROXY command (0x21), got "
+                "{0:#x}".format(preamble[12]))
+        if preamble[13] != 0x31:
+            raise Exception(
+                "expected AF_UNIX/STREAM family byte (0x31), got "
+                "{0:#x}".format(preamble[13]))
+        addr_len = int.from_bytes(preamble[14:16], 'big')
+        # AF_UNIX address block is two 108-byte sun_path fields.
+        if addr_len != 216:
+            raise Exception(
+                "expected 216-byte AF_UNIX address block, got "
+                "{0}".format(addr_len))
+        recv_exact(addr_len, "AF_UNIX address block")
+        print_ok("backend received PROXY v2 header (AF_UNIX/STREAM)")
 
-        try:
-            tls.close()
-        except Exception:
-            # best-effort cleanup: tls may already be torn down by ghostunnel
-            pass
+        # Payload must flow after the header.
+        tls.send(b'hello unix')
+        data = recv_exact(len(b'hello unix'), "forwarded payload")
+        if data != b'hello unix':
+            raise Exception(
+                "client->server payload mismatch: {0!r}".format(data))
+        print_ok("payload forwarded after PROXY header")
+
+        tls.close()
         conn.close()
     finally:
         terminate(handle)


### PR DESCRIPTION
Fixed transportProtocol to map *net.UnixAddr to proxyproto.UnixStream and fall back to UNSPEC instead of misreporting TCPv4 for unknown address types.