### PR TITLE
Fix: wildcard.CompileWithSeparator does not regex-quote the separator

### DIFF
--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -111,11 +111,10 @@ func CompileWithSeparator(pattern string, separator rune) (Matcher, error) {
 
 	// Quote the separator so it can be safely emitted into the generated
 	// regular expression. Outside a character class, regexp.QuoteMeta is
-	// sufficient. Inside a [^...] character class, QuoteMeta is not safe
-	// (it does not escape ']', '\\', or '^'), and a simple "\\" + sep is
-	// also not safe (e.g. '\d', '\w', '\s' are character classes; '\b' is
-	// not a valid escape at all). Use an explicit Unicode hex escape, which
-	// is supported by RE2 inside character classes for any rune.
+	// sufficient. Inside a [^...] character class, escaping rules differ
+	// (e.g. '-' is special and '\\d', '\\w', '\\s' are parsed as character classes),
+	// so use an explicit Unicode code-point escape, which is safe in RE2
+	// character classes for any rune.
 	sepOutside := regexp.QuoteMeta(string(separator))
 	sepInsideClass := fmt.Sprintf(`\x{%X}`, separator)
 

--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -41,6 +41,7 @@ package wildcard
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -108,6 +109,16 @@ func CompileWithSeparator(pattern string, separator rune) (Matcher, error) {
 
 	segments := strings.Split(pattern, string(separator))
 
+	// Quote the separator so it can be safely emitted into the generated
+	// regular expression. Outside a character class, regexp.QuoteMeta is
+	// sufficient. Inside a [^...] character class, QuoteMeta is not safe
+	// (it does not escape ']', '\\', or '^'), and a simple "\\" + sep is
+	// also not safe (e.g. '\d', '\w', '\s' are character classes; '\b' is
+	// not a valid escape at all). Use an explicit Unicode hex escape, which
+	// is supported by RE2 inside character classes for any rune.
+	sepOutside := regexp.QuoteMeta(string(separator))
+	sepInsideClass := fmt.Sprintf(`\x{%X}`, separator)
+
 	var regex bytes.Buffer
 	regex.WriteString("^")
 
@@ -117,7 +128,7 @@ loop:
 		case "*":
 			// Segment with wildcard
 			regex.WriteString("[^")
-			regex.WriteRune(separator)
+			regex.WriteString(sepInsideClass)
 			regex.WriteString("]+")
 		case "**":
 			// Segment with double wildcard
@@ -126,7 +137,7 @@ loop:
 				return nil, errInvalidDoubleWildcard
 			}
 			regex.WriteString("?(|")
-			regex.WriteRune(separator)
+			regex.WriteString(sepOutside)
 			regex.WriteString(".*)$")
 			break loop
 		default:
@@ -138,7 +149,7 @@ loop:
 		}
 
 		// Separate this segment from next one
-		regex.WriteRune(separator)
+		regex.WriteString(sepOutside)
 
 		if i == len(segments)-1 {
 			// Final slash should be optional

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -256,6 +256,229 @@ func TestMatchingWithMetaChars(t *testing.T) {
 		})
 }
 
+func TestCompileWithSeparatorMetaChars(t *testing.T) {
+	// Each case uses a regex metacharacter as the separator. The pattern
+	// is interpreted with that separator, not '/'. A '*' segment must match
+	// any literal that does not contain the separator, and literal segments
+	// must match exactly.
+	tests := []struct {
+		name      string
+		separator rune
+		pattern   string
+		matches   []string
+		nomatches []string
+	}{
+		{
+			name:      "dot separator",
+			separator: '.',
+			pattern:   "a.*.b",
+			matches: []string{
+				"a.foo.b",
+				"a.foo.b.",
+			},
+			nomatches: []string{
+				// '.' should NOT act as a regex wildcard.
+				"aXfooXb",
+				"aXb",
+				// '*' segment must not span the separator.
+				"a.foo.bar.b",
+				// No literal match for empty/missing wildcard segment.
+				"a..b",
+				// Outright non-matches.
+				"a.b",
+				"",
+			},
+		},
+		{
+			name:      "literal dot separator (no wildcard)",
+			separator: '.',
+			pattern:   "a.b",
+			matches: []string{
+				"a.b",
+				"a.b.",
+			},
+			nomatches: []string{
+				// '.' should NOT act as a regex wildcard.
+				"aXb",
+				"a-b",
+				"ab",
+			},
+		},
+		{
+			name:      "pipe separator",
+			separator: '|',
+			pattern:   "a|*|b",
+			matches: []string{
+				"a|foo|b",
+				"a|foo|b|",
+			},
+			nomatches: []string{
+				// '|' should NOT act as a regex alternation.
+				"a",
+				"b",
+				"ab",
+				"a|b",
+				"a|foo|bar|b",
+			},
+		},
+		{
+			name:      "plus separator",
+			separator: '+',
+			pattern:   "a+*+b",
+			matches: []string{
+				"a+foo+b",
+				"a+foo+b+",
+			},
+			nomatches: []string{
+				// '+' should NOT quantify the preceding char.
+				"aaab",
+				"a+b",
+				"a+foo+bar+b",
+			},
+		},
+		{
+			name:      "question mark separator",
+			separator: '?',
+			pattern:   "a?*?b",
+			matches: []string{
+				"a?foo?b",
+				"a?foo?b?",
+			},
+			nomatches: []string{
+				// '?' should NOT make preceding char optional.
+				"ab",
+				"a?b",
+				"a?foo?bar?b",
+			},
+		},
+		{
+			name:      "star separator (literal segment only)",
+			separator: '*',
+			// We cannot use '*' as a wildcard segment when '*' is also the
+			// separator (it would just be a separator); test literal segments.
+			pattern: "a*b",
+			matches: []string{
+				"a*b",
+				"a*b*",
+			},
+			nomatches: []string{
+				// '*' should NOT quantify the preceding char.
+				"aaab",
+				"ab",
+				"a*b*c",
+			},
+		},
+		{
+			name:      "closing bracket separator",
+			separator: ']',
+			pattern:   "a]*]b",
+			matches: []string{
+				"a]foo]b",
+				"a]foo]b]",
+			},
+			nomatches: []string{
+				// ']' must not break the character class in [^]]+.
+				"a]b",
+				"a]foo]bar]b",
+				"ab",
+			},
+		},
+		{
+			name:      "backslash separator",
+			separator: '\\',
+			pattern:   "a\\*\\b",
+			matches: []string{
+				"a\\foo\\b",
+				"a\\foo\\b\\",
+			},
+			nomatches: []string{
+				// '\' must not introduce an escape sequence.
+				"a\\b",
+				"a\\foo\\bar\\b",
+				"ab",
+			},
+		},
+		{
+			name:      "caret separator",
+			separator: '^',
+			pattern:   "a^*^b",
+			matches: []string{
+				"a^foo^b",
+				"a^foo^b^",
+			},
+			nomatches: []string{
+				// '^' must not negate inside the character class or anchor
+				// inappropriately.
+				"a^b",
+				"a^foo^bar^b",
+				"ab",
+			},
+		},
+		{
+			// Letter separators must not be interpreted as character-class
+			// escapes inside [^...]. In particular, '\d' (digit), '\w' (word),
+			// '\s' (space), and their uppercase variants are RE2 escapes; '\b'
+			// is not a valid escape at all (would fail to compile).
+			name:      "letter separator d (regex \\d escape)",
+			separator: 'd',
+			pattern:   "xdyd*dxdy",
+			matches: []string{
+				// wildcard should match any non-'d' string, including digits.
+				"xdyd9dxdy",
+				"xdydXdxdy",
+				"xdyd1234dxdy",
+				"xdyd9dxdyd",
+			},
+			nomatches: []string{
+				// wildcard must not span the separator.
+				"xdydadbdxdy",
+				"xdydXdYdxdy",
+				// '*' must match at least one character.
+				"xdyddxdy",
+				"xdyXdxdy",
+			},
+		},
+		{
+			// 'b' as a separator is the worst case: "\b" is not a valid RE2
+			// escape, so naively writing "[^\b]+" fails to compile.
+			name:      "letter separator b (invalid \\b escape)",
+			separator: 'b',
+			pattern:   "ab*ba",
+			matches: []string{
+				"abXba",
+				"abXYZba",
+				"abXbab",
+			},
+			nomatches: []string{
+				"abba",
+				"abbXba",
+				"aXa",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			matcher, err := CompileWithSeparator(tc.pattern, tc.separator)
+			if err != nil {
+				t.Fatalf("CompileWithSeparator(%q, %q) failed: %s", tc.pattern, tc.separator, err)
+			}
+			t.Logf("pattern=%q sep=%q => regex=%q", tc.pattern, tc.separator, matcher.(regexpMatcher).pattern.String())
+			for _, in := range tc.matches {
+				if !matcher.Matches(in) {
+					t.Errorf("pattern %q (sep %q) did not match %q, but should have", tc.pattern, tc.separator, in)
+				}
+			}
+			for _, in := range tc.nomatches {
+				if matcher.Matches(in) {
+					t.Errorf("pattern %q (sep %q) matched %q, but should not have", tc.pattern, tc.separator, in)
+				}
+			}
+		})
+	}
+}
+
 func TestInvalidPatterns(t *testing.T) {
 	for _, pattern := range []string{
 		"",


### PR DESCRIPTION
In wildcard/matcher.go, pre-computed two quoted forms of the separator: regexp.QuoteMeta for use outside character classes, and a manual backslash escape ("\\" + sep) for use inside the [^...] class (since QuoteMeta does not escape ']', '\\', or '^' which have special meaning inside character classes). Replaced all WriteRune(separator) sites with the appropriate quoted form. Added a table-driven test covering '.', '|', '+', '?', '*', ']', '\\', and '^' separators.