### PR TITLE
Fix: Wildcard trailing-separator handling + bare ** behavior

### DIFF
--- a/wildcard/matcher.go
+++ b/wildcard/matcher.go
@@ -31,11 +31,15 @@
 // pattern.
 //
 // (2) A double '**' wildcard will match anything, including the separator
-// rune. It may only occur at the end of a pattern, after a separator.
+// rune. It may only occur at the end of a pattern, either after a separator
+// or as the entire pattern (in which case it matches any input).
 //
 // Furthermore, the matcher will consider the separator optional if it occurs
 // at the end of a string. This means that, for example, the strings
-// "test://foo/bar" and "test://foo/bar/" are treated as equivalent.
+// "test://foo/bar" and "test://foo/bar/" are treated as equivalent. The same
+// holds for patterns: a single trailing separator is stripped before
+// compilation, so the patterns "foo" and "foo/" are equivalent and accept the
+// same set of inputs.
 package wildcard
 
 import (
@@ -104,6 +108,29 @@ func CompileWithSeparator(pattern string, separator rune) (Matcher, error) {
 
 	if pattern == "" {
 		return nil, errEmptyPattern
+	}
+
+	// Normalize: strip a single trailing separator so that "foo" and "foo/"
+	// compile to the same regex. This keeps the documented input-side
+	// equivalence ("test://foo/bar" ~ "test://foo/bar/") symmetric on the
+	// pattern side. We don't strip if the pattern is just the separator
+	// itself, as that would leave us with an empty pattern.
+	sepStr := string(separator)
+	if len(pattern) > len(sepStr) && strings.HasSuffix(pattern, sepStr) {
+		pattern = pattern[:len(pattern)-len(sepStr)]
+	}
+
+	// Special case: a bare "**" matches anything. The documented grammar
+	// requires "**" to follow a separator, but historically a bare "**" has
+	// been accepted (and matched everything by accident of regex parsing).
+	// Compile it explicitly so the behavior is intentional rather than
+	// emergent.
+	if pattern == "**" {
+		compiled, err := regexp.Compile("^.*$")
+		if err != nil {
+			return nil, errRegexpCompile
+		}
+		return regexpMatcher{pattern: compiled}, nil
 	}
 
 	segments := strings.Split(pattern, string(separator))

--- a/wildcard/matcher_test.go
+++ b/wildcard/matcher_test.go
@@ -352,6 +352,140 @@ func TestCompileWithSeparator(t *testing.T) {
 	}
 }
 
+// TestTrailingSeparatorNormalization verifies that a single trailing
+// separator on the pattern is stripped before compilation, so that
+// "foo" and "foo/" accept the same set of inputs.
+func TestTrailingSeparatorNormalization(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		matches []string
+		nope    []string
+	}{
+		{
+			name:    "trailing separator on literal",
+			pattern: "test://foo/bar/",
+			matches: []string{
+				"test://foo/bar",
+				"test://foo/bar/",
+			},
+			nope: []string{
+				"test://foo/bar//",
+				"test://foo/baz",
+				"test://foo",
+				"",
+			},
+		},
+		{
+			name:    "no trailing separator on literal",
+			pattern: "test://foo/bar",
+			matches: []string{
+				"test://foo/bar",
+				"test://foo/bar/",
+			},
+			nope: []string{
+				"test://foo/bar//",
+				"test://foo/baz",
+				"test://foo",
+				"",
+			},
+		},
+		{
+			name:    "trailing separator with wildcard",
+			pattern: "test://foo/*/",
+			matches: []string{
+				"test://foo/baz",
+				"test://foo/baz/",
+				"test://foo/spam",
+				"test://foo/spam/",
+			},
+			nope: []string{
+				"test://foo/baz//",
+				"test://foo",
+				"test://foo/",
+				"test://foo/baz/bar",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testMatches(t, tc.pattern, tc.matches, tc.nope)
+		})
+	}
+}
+
+// TestTrailingSeparatorEquivalence verifies that "foo" and "foo/"
+// compile to equivalent patterns: each accepts exactly the same set
+// of inputs (in both directions).
+func TestTrailingSeparatorEquivalence(t *testing.T) {
+	pairs := []struct {
+		a, b string
+	}{
+		{"foo", "foo/"},
+		{"test://foo/bar", "test://foo/bar/"},
+		{"test://foo/*/bar", "test://foo/*/bar/"},
+		{"test://foo/**", "test://foo/**/"},
+	}
+	probes := []string{
+		"foo",
+		"foo/",
+		"foo/x",
+		"test://foo/bar",
+		"test://foo/bar/",
+		"test://foo/bar//",
+		"test://foo/bar/baz",
+		"test://foo/baz/bar",
+		"test://foo/baz/bar/",
+		"test://foo/x/bar/y",
+		"",
+	}
+	for _, p := range pairs {
+		p := p
+		t.Run(p.a+"_vs_"+p.b, func(t *testing.T) {
+			ma, err := Compile(p.a)
+			if err != nil {
+				t.Fatalf("compile %q: %s", p.a, err)
+			}
+			mb, err := Compile(p.b)
+			if err != nil {
+				t.Fatalf("compile %q: %s", p.b, err)
+			}
+			for _, probe := range probes {
+				if ma.Matches(probe) != mb.Matches(probe) {
+					t.Errorf("patterns %q and %q disagree on input %q (%t vs %t)",
+						p.a, p.b, probe, ma.Matches(probe), mb.Matches(probe))
+				}
+			}
+		})
+	}
+}
+
+// TestBareDoubleWildcard verifies that the bare "**" pattern is
+// accepted and matches any input, including the empty string and
+// strings containing separators. This behaviour is documented as a
+// special case rather than emerging from the regex compiler's parse.
+func TestBareDoubleWildcard(t *testing.T) {
+	matcher, err := Compile("**")
+	if err != nil {
+		t.Fatalf("bare ** should compile, got error: %s", err)
+	}
+	inputs := []string{
+		"",
+		"foo",
+		"foo/bar",
+		"foo/bar/baz",
+		"/",
+		"//",
+		"a/b/c/d",
+		"test://foo/bar",
+	}
+	for _, in := range inputs {
+		if !matcher.Matches(in) {
+			t.Errorf("bare ** should match %q but did not", in)
+		}
+	}
+}
+
 func TestCompileList(t *testing.T) {
 	// Compile with valid patterns
 	ms, err := CompileList([]string{


### PR DESCRIPTION
In wildcard/matcher.go, normalize a single trailing separator before compiling (so "foo/" is equivalent to "foo") and special-case the bare "\*\*" pattern to compile to "^.\*$" instead of relying on the accidental "^?(|/.\*)$" parse. Updated the package doc comment to reflect both choices and added table-driven tests for trailing-separator handling and bare "\*\*".