### PR TITLE
Fix icons alignment on releases page

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -1304,6 +1304,12 @@ a:hover {
   gap: 0.75rem;
 }
 
+.release-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+}
+
 /* =============================================
    Badge
    ============================================= */


### PR DESCRIPTION
Fix icons alignment on releases page. They were a bit too high in the links to github/docker hub previously. 