### PR TITLE
Fix: Server --target systemd:/launchd: validates but cannot dial

### DIFF
--- a/main.go
+++ b/main.go
@@ -924,6 +924,14 @@ func serverBackendDialer() (proxy.DialFunc, error) {
 		return nil, err
 	}
 
+	// Socket-activation networks ("systemd"/"launchd") only make sense for
+	// listening, not dialing. net.Dialer cannot dial them, so reject these
+	// targets at startup with a clear error rather than failing on every
+	// connection with "dial systemd: unknown network systemd".
+	if backendNet != "tcp" && backendNet != "unix" {
+		return nil, fmt.Errorf("invalid --target network %q: only tcp and unix targets are supported (systemd:/launchd: cannot be dialed)", backendNet)
+	}
+
 	return func(ctx context.Context) (net.Conn, error) {
 		d := net.Dialer{Timeout: *connectTimeout}
 		return d.DialContext(ctx, backendNet, backendAddr)

--- a/main_test.go
+++ b/main_test.go
@@ -419,6 +419,40 @@ func TestServerBackendDialerError(t *testing.T) {
 	assert.NotNil(t, err, "invalid forward address should not have dialer")
 }
 
+func TestServerBackendDialerRejectsSystemd(t *testing.T) {
+	original := *serverForwardAddress
+	defer func() { *serverForwardAddress = original }()
+
+	*serverForwardAddress = "systemd:foo"
+	_, err := serverBackendDialer()
+	assert.NotNil(t, err, "systemd: target should be rejected at startup")
+	if err != nil {
+		assert.Contains(t, err.Error(), "systemd", "error message should mention the offending network")
+	}
+}
+
+func TestServerBackendDialerRejectsLaunchd(t *testing.T) {
+	original := *serverForwardAddress
+	defer func() { *serverForwardAddress = original }()
+
+	*serverForwardAddress = "launchd:foo"
+	_, err := serverBackendDialer()
+	assert.NotNil(t, err, "launchd: target should be rejected at startup")
+	if err != nil {
+		assert.Contains(t, err.Error(), "launchd", "error message should mention the offending network")
+	}
+}
+
+func TestServerBackendDialerAcceptsUnix(t *testing.T) {
+	original := *serverForwardAddress
+	defer func() { *serverForwardAddress = original }()
+
+	*serverForwardAddress = "unix:/tmp/ghostunnel-target-test.sock"
+	dial, err := serverBackendDialer()
+	assert.Nil(t, err, "unix: target should be accepted")
+	assert.NotNil(t, dial, "unix: target should produce a dialer")
+}
+
 func TestInvalidCABundle(t *testing.T) {
 	cmd := []string{
 		"server",

--- a/main_test.go
+++ b/main_test.go
@@ -414,6 +414,9 @@ func TestDisallowsFooDotCom(t *testing.T) {
 }
 
 func TestServerBackendDialerError(t *testing.T) {
+	original := *serverForwardAddress
+	defer func() { *serverForwardAddress = original }()
+
 	*serverForwardAddress = "invalid"
 	_, err := serverBackendDialer()
 	assert.NotNil(t, err, "invalid forward address should not have dialer")


### PR DESCRIPTION
Reject systemd:/launchd: target networks inside serverBackendDialer with a clear error before returning the dial function. The consideredSafe safe-prefix list is left untouched so it continues to allow these prefixes for listens, which is correct.