### PR TITLE
Fix: Duplicated cipher-suite parsing logic can drift

### DIFF
--- a/main.go
+++ b/main.go
@@ -296,15 +296,8 @@ func validateCredentials(creds []bool) int {
 }
 
 func validateCipherSuites() error {
-	for suite := range strings.SplitSeq(*enabledCipherSuites, ",") {
-		name := strings.TrimSpace(suite)
-		_, ok := cipherSuites[name]
-		if !ok && *allowUnsafeCipherSuites {
-			_, ok = unsafeCipherSuites[name]
-		}
-		if !ok {
-			return fmt.Errorf("invalid cipher suite option: %s", suite)
-		}
+	if _, err := resolveCipherSuites(*enabledCipherSuites, *allowUnsafeCipherSuites); err != nil {
+		return fmt.Errorf("invalid cipher suite option: %w", err)
 	}
 	return nil
 }
@@ -689,7 +682,7 @@ func run(args []string) error {
 // connections. This is useful for the purpose of replacing certificates
 // in-place without having to take downtime, e.g. if a certificate is expiring.
 func serverListen(env *Environment) error {
-	config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion)
+	config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
 	if err != nil {
 		logger.Printf("error trying to read CA bundle: %s", err)
 		return err
@@ -875,7 +868,7 @@ func (env *Environment) serveStatus() error {
 	}
 
 	if network != "unix" && https && env.tlsConfigSource.CanServe() {
-		config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion)
+		config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
 		if err != nil {
 			return err
 		}
@@ -923,7 +916,7 @@ func clientBackendDialer(
 	network, address, host string,
 ) (proxy.DialFunc, policy.Policy, error) {
 
-	config, err := buildClientConfig(*enabledCipherSuites, *maxTLSVersion)
+	config, err := buildClientConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func validateCredentials(creds []bool) int {
 
 func validateCipherSuites() error {
 	if _, err := resolveCipherSuites(*enabledCipherSuites, *allowUnsafeCipherSuites); err != nil {
-		return fmt.Errorf("invalid cipher suite option: %w", err)
+		return err
 	}
 	return nil
 }

--- a/tls.go
+++ b/tls.go
@@ -102,17 +102,21 @@ func parseTLSVersion(version string) (uint16, error) {
 	}
 }
 
-// buildConfig builds a generic tls.Config
-func buildConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.Config, error) {
-	// List of cipher suite preferences:
-	// * We list ECDSA ahead of RSA to prefer ECDSA for multi-cert setups.
-	// * We list AES-128 ahead of AES-256 for performance reasons.
-
+// resolveCipherSuites parses a comma-separated list of cipher-suite group
+// names (e.g. "AES,CHACHA") and returns the concatenated list of underlying
+// tls cipher-suite IDs. If allowUnsafe is true, names from unsafeCipherSuites
+// are also accepted as a fallback.
+//
+// This helper is the single source of truth shared by validateCipherSuites
+// (early validation at flag-parse time) and buildConfig (used to construct
+// the runtime tls.Config). Keeping the lookup in one place ensures the two
+// call sites cannot drift apart.
+func resolveCipherSuites(spec string, allowUnsafe bool) ([]uint16, error) {
 	suites := []uint16{}
-	for suite := range strings.SplitSeq(enabledCipherSuites, ",") {
+	for suite := range strings.SplitSeq(spec, ",") {
 		name := strings.TrimSpace(suite)
 		ciphers, ok := cipherSuites[name]
-		if !ok && *allowUnsafeCipherSuites {
+		if !ok && allowUnsafe {
 			ciphers, ok = unsafeCipherSuites[name]
 		}
 		if !ok {
@@ -120,6 +124,19 @@ func buildConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.Config,
 		}
 
 		suites = append(suites, ciphers...)
+	}
+	return suites, nil
+}
+
+// buildConfig builds a generic tls.Config
+func buildConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool) (*tls.Config, error) {
+	// List of cipher suite preferences:
+	// * We list ECDSA ahead of RSA to prefer ECDSA for multi-cert setups.
+	// * We list AES-128 ahead of AES-256 for performance reasons.
+
+	suites, err := resolveCipherSuites(enabledCipherSuites, allowUnsafe)
+	if err != nil {
+		return nil, err
 	}
 
 	config := &tls.Config{
@@ -140,15 +157,15 @@ func buildConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.Config,
 }
 
 // buildClientConfig builds a tls.Config for clients
-func buildClientConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.Config, error) {
+func buildClientConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool) (*tls.Config, error) {
 	// At the moment, we don't apply any extra settings on top of the generic
 	// config for client contexts
-	return buildConfig(enabledCipherSuites, maxTLSVersion)
+	return buildConfig(enabledCipherSuites, maxTLSVersion, allowUnsafe)
 }
 
 // buildServerConfig builds a tls.Config for servers
-func buildServerConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.Config, error) {
-	config, err := buildConfig(enabledCipherSuites, maxTLSVersion)
+func buildServerConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool) (*tls.Config, error) {
+	config, err := buildConfig(enabledCipherSuites, maxTLSVersion, allowUnsafe)
 	if err != nil {
 		return nil, err
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -236,19 +236,19 @@ func TestBuildConfig(t *testing.T) {
 	defer os.Remove(tmpKeystoreSeparateCert.Name())
 	defer os.Remove(tmpKeystoreSeparateKey.Name())
 
-	_, err = buildConfig("", "")
+	_, err = buildConfig("", "", false)
 	assert.NotNil(t, err, "should fail to build config with no cipher suites")
 
-	conf, err := buildConfig("AES,CHACHA", "")
+	conf, err := buildConfig("AES,CHACHA", "", false)
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.MinVersion == tls.VersionTLS12, "must have correct TLS min version")
 	assert.Equal(t, uint16(0), conf.MaxVersion, "should not set MaxVersion when maxTLSVersion is empty")
 
-	conf, err = buildConfig("AES,CHACHA", "TLS1.3")
+	conf, err = buildConfig("AES,CHACHA", "TLS1.3", false)
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.MaxVersion == tls.VersionTLS13, "must have correct TLS max version")
 
-	_, err = buildConfig("AES,CHACHA", "invalid")
+	_, err = buildConfig("AES,CHACHA", "invalid", false)
 	assert.NotNil(t, err, "should fail to build config with invalid TLS version")
 	assert.Contains(t, err.Error(), "invalid max TLS version", "error should mention invalid TLS version")
 
@@ -279,20 +279,20 @@ func TestBuildConfig(t *testing.T) {
 }
 
 func TestBuildClientConfig(t *testing.T) {
-	conf, err := buildClientConfig("AES,CHACHA", "")
+	conf, err := buildClientConfig("AES,CHACHA", "", false)
 	assert.Nil(t, err, "should be able to build client TLS config")
 	assert.True(t, conf.MinVersion == tls.VersionTLS12, "must have correct TLS min version")
 
-	conf, err = buildClientConfig("AES,CHACHA", "TLS1.2")
+	conf, err = buildClientConfig("AES,CHACHA", "TLS1.2", false)
 	assert.Nil(t, err, "should be able to build client TLS config with max version")
 	assert.Equal(t, uint16(tls.VersionTLS12), conf.MaxVersion, "must have correct max TLS version")
 
-	_, err = buildClientConfig("INVALID", "")
+	_, err = buildClientConfig("INVALID", "", false)
 	assert.NotNil(t, err, "should fail to build client config with invalid cipher suite")
 }
 
 func TestBuildServerConfig(t *testing.T) {
-	conf, err := buildServerConfig("AES,CHACHA", "")
+	conf, err := buildServerConfig("AES,CHACHA", "", false)
 	assert.Nil(t, err, "should be able to build server TLS config")
 	assert.Equal(t, tls.RequireAndVerifyClientCert, conf.ClientAuth, "server config should require client cert")
 	assert.Contains(t, conf.CurvePreferences, tls.X25519, "should include X25519 curve")
@@ -336,31 +336,109 @@ func TestBuildCertificateNoCert(t *testing.T) {
 }
 
 func TestCipherSuitePreference(t *testing.T) {
-	_, err := buildConfig("XYZ", "TLS1.3")
+	_, err := buildConfig("XYZ", "TLS1.3", false)
 	assert.NotNil(t, err, "should not be able to build TLS config with invalid cipher suite option")
 
-	_, err = buildServerConfig("XYZ", "TLS1.3")
+	_, err = buildServerConfig("XYZ", "TLS1.3", false)
 	assert.NotNil(t, err, "should not be able to build server TLS config with invalid cipher suite option")
 
-	_, err = buildConfig("", "TLS1.3")
+	_, err = buildConfig("", "TLS1.3", false)
 	assert.NotNil(t, err, "should not be able to build TLS config wihout cipher suite selection")
 
-	conf, err := buildConfig("CHACHA,AES", "TLS1.3")
+	conf, err := buildConfig("CHACHA,AES", "TLS1.3", false)
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_CHACHA20_POLY1305_SHA256, "expecting TLS 1.3 ChaCha20")
 
-	conf, err = buildConfig("AES,CHACHA", "TLS1.3")
+	conf, err = buildConfig("AES,CHACHA", "TLS1.3", false)
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_AES_128_GCM_SHA256, "expecting TLS 1.3 AES")
 
-	_, err = buildConfig("AES,CHACHA,UNSAFE-AZURE", "TLS1.3")
+	_, err = buildConfig("AES,CHACHA,UNSAFE-AZURE", "TLS1.3", false)
 	assert.NotNil(t, err, "should not be able to build TLS config with unsafe cipher suite without flag")
 
-	*allowUnsafeCipherSuites = true
-	conf, err = buildConfig("UNSAFE-AZURE", "TLS1.3")
+	conf, err = buildConfig("UNSAFE-AZURE", "TLS1.3", true)
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, "expecting AES")
-	*allowUnsafeCipherSuites = false
+}
+
+// TestResolveCipherSuites exercises the shared helper used by both
+// validateCipherSuites and buildConfig. The helper is the single source of
+// truth for cipher-suite parsing/lookup, so these cases lock its behavior in.
+func TestResolveCipherSuites(t *testing.T) {
+	// Known safe group resolves.
+	suites, err := resolveCipherSuites("AES", false)
+	assert.Nil(t, err, "AES group should resolve without unsafe flag")
+	assert.NotEmpty(t, suites, "AES group should yield non-empty suite list")
+
+	// Whitespace around names is trimmed.
+	suites, err = resolveCipherSuites(" AES , CHACHA ", false)
+	assert.Nil(t, err, "names with surrounding whitespace should be trimmed")
+	assert.NotEmpty(t, suites)
+
+	// Unknown group is rejected.
+	_, err = resolveCipherSuites("XYZ", false)
+	assert.NotNil(t, err, "unknown group should be rejected")
+
+	// Empty spec yields the empty-name lookup which is rejected.
+	_, err = resolveCipherSuites("", false)
+	assert.NotNil(t, err, "empty spec should be rejected")
+
+	// Unsafe group requires the explicit allowUnsafe flag.
+	_, err = resolveCipherSuites("UNSAFE-AZURE", false)
+	assert.NotNil(t, err, "unsafe group should be rejected when allowUnsafe=false")
+
+	suites, err = resolveCipherSuites("UNSAFE-AZURE", true)
+	assert.Nil(t, err, "unsafe group should resolve when allowUnsafe=true")
+	assert.Equal(t, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256}, suites)
+
+	// Mixing safe and unsafe names: still requires the flag.
+	_, err = resolveCipherSuites("AES,UNSAFE-AZURE", false)
+	assert.NotNil(t, err, "mixed safe+unsafe should be rejected without flag")
+
+	suites, err = resolveCipherSuites("AES,UNSAFE-AZURE", true)
+	assert.Nil(t, err, "mixed safe+unsafe should resolve with flag")
+	assert.Contains(t, suites, uint16(tls.TLS_AES_128_GCM_SHA256))
+	assert.Contains(t, suites, uint16(tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256))
+}
+
+// TestValidateCipherSuitesMatchesBuildConfig pins the invariant that
+// validateCipherSuites and buildConfig accept/reject the exact same inputs.
+// Both call resolveCipherSuites under the hood; if either ever diverges this
+// test will catch it.
+func TestValidateCipherSuitesMatchesBuildConfig(t *testing.T) {
+	origSpec := *enabledCipherSuites
+	origUnsafe := *allowUnsafeCipherSuites
+	defer func() {
+		*enabledCipherSuites = origSpec
+		*allowUnsafeCipherSuites = origUnsafe
+	}()
+
+	cases := []struct {
+		spec        string
+		allowUnsafe bool
+	}{
+		{"AES", false},
+		{"AES,CHACHA", false},
+		{"XYZ", false},
+		{"", false},
+		{"UNSAFE-AZURE", false},
+		{"UNSAFE-AZURE", true},
+		{"AES,UNSAFE-AZURE", false},
+		{"AES,UNSAFE-AZURE", true},
+		{" AES , CHACHA ", false},
+	}
+	for _, tc := range cases {
+		*enabledCipherSuites = tc.spec
+		*allowUnsafeCipherSuites = tc.allowUnsafe
+
+		validateErr := validateCipherSuites()
+		_, buildErr := buildConfig(tc.spec, "", tc.allowUnsafe)
+
+		assert.Equal(t,
+			validateErr == nil, buildErr == nil,
+			"validateCipherSuites and buildConfig must agree for spec=%q allowUnsafe=%v (validateErr=%v buildErr=%v)",
+			tc.spec, tc.allowUnsafe, validateErr, buildErr)
+	}
 }
 
 func TestReload(t *testing.T) {


### PR DESCRIPTION
Extracted a shared resolveCipherSuites(spec, allowUnsafe) helper in tls.go that is the single source of truth for cipher-suite parsing; rewrote validateCipherSuites to delegate to it; and threaded an explicit allowUnsafe parameter through buildConfig/buildClientConfig/buildServerConfig so the global *allowUnsafeCipherSuites is no longer read inside those builders.