### PR TITLE
Fix: Data race on env.regoPolicy between startup and timed-reload goroutine

### DIFF
--- a/main.go
+++ b/main.go
@@ -604,13 +604,9 @@ func run(args []string) error {
 		// Compile the rego policy before constructing the Environment so the
 		// reload goroutine (started below) does not race with a later
 		// assignment to env.regoPolicy.
-		var regoPolicy policy.Policy
-		if len(*serverAllowPolicy) > 0 && len(*serverAllowQuery) > 0 {
-			regoPolicy, err = policy.LoadFromPath(*serverAllowPolicy, *serverAllowQuery)
-			if err != nil {
-				logger.Printf("Invalid rego policy or query: %s", err)
-				return err
-			}
+		regoPolicy, err := loadOPAPolicy(*serverAllowPolicy, *serverAllowQuery)
+		if err != nil {
+			return err
 		}
 
 		status := newStatusHandler(dial, command, *serverListenAddress, *serverForwardAddress, *serverStatusTargetAddress)
@@ -687,6 +683,21 @@ func run(args []string) error {
 	}
 
 	return errors.New("unknown command")
+}
+
+// loadOPAPolicy compiles a rego policy from the given path+query. Returns
+// (nil, nil) when either flag is empty (OPA disabled); otherwise loads the
+// policy and returns it, or an error if compilation fails.
+func loadOPAPolicy(allowPolicy, allowQuery string) (policy.Policy, error) {
+	if len(allowPolicy) == 0 || len(allowQuery) == 0 {
+		return nil, nil
+	}
+	p, err := policy.LoadFromPath(allowPolicy, allowQuery)
+	if err != nil {
+		logger.Printf("Invalid rego policy or query: %s", err)
+		return nil, err
+	}
+	return p, nil
 }
 
 // Open listening socket in server mode. Take note that we create a
@@ -955,14 +966,9 @@ func clientBackendDialer(
 		return nil, nil, err
 	}
 
-	// Compile the rego policy
-	var regoPolicy policy.Policy
-	if len(*clientAllowPolicy) > 0 && len(*clientAllowQuery) > 0 {
-		regoPolicy, err = policy.LoadFromPath(*clientAllowPolicy, *clientAllowQuery)
-		if err != nil {
-			logger.Printf("Invalid rego policy or query: %s", err)
-			return nil, nil, err
-		}
+	regoPolicy, err := loadOPAPolicy(*clientAllowPolicy, *clientAllowQuery)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	clientACL := auth.ACL{

--- a/main.go
+++ b/main.go
@@ -601,6 +601,18 @@ func run(args []string) error {
 		}
 		logger.Printf("using target address %s", *serverForwardAddress)
 
+		// Compile the rego policy before constructing the Environment so the
+		// reload goroutine (started below) does not race with a later
+		// assignment to env.regoPolicy.
+		var regoPolicy policy.Policy
+		if len(*serverAllowPolicy) > 0 && len(*serverAllowQuery) > 0 {
+			regoPolicy, err = policy.LoadFromPath(*serverAllowPolicy, *serverAllowQuery)
+			if err != nil {
+				logger.Printf("Invalid rego policy or query: %s", err)
+				return err
+			}
+		}
+
 		status := newStatusHandler(dial, command, *serverListenAddress, *serverForwardAddress, *serverStatusTargetAddress)
 		env := &Environment{
 			status:          status,
@@ -609,11 +621,12 @@ func run(args []string) error {
 			dial:            dial,
 			metrics:         metrics,
 			tlsConfigSource: tlsConfigSource,
+			regoPolicy:      regoPolicy,
 		}
 		go env.reloadHandler(*timedReload)
 
 		// Start listening
-		err = serverListen(env)
+		err = serverListen(env, regoPolicy)
 		if err != nil {
 			logger.Printf("error from server listen: %s\n", err)
 		}
@@ -681,7 +694,7 @@ func run(args []string) error {
 // allows us to have multiple sockets listening on the same port and accept
 // connections. This is useful for the purpose of replacing certificates
 // in-place without having to take downtime, e.g. if a certificate is expiring.
-func serverListen(env *Environment) error {
+func serverListen(env *Environment, regoPolicy policy.Policy) error {
 	config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
 	if err != nil {
 		logger.Printf("error trying to read CA bundle: %s", err)
@@ -692,18 +705,6 @@ func serverListen(env *Environment) error {
 	if err != nil {
 		logger.Printf("invalid URI pattern in --allow-uri flag (%s)", err)
 		return err
-	}
-
-	// Compile the rego policy
-	var regoPolicy policy.Policy
-	if len(*serverAllowPolicy) > 0 && len(*serverAllowQuery) > 0 {
-		regoPolicy, err = policy.LoadFromPath(*serverAllowPolicy, *serverAllowQuery)
-		if err != nil {
-			logger.Printf("Invalid rego policy or query: %s", err)
-			return err
-		}
-
-		env.regoPolicy = regoPolicy
 	}
 
 	serverACL := auth.ACL{

--- a/main_test.go
+++ b/main_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -1493,5 +1494,65 @@ func TestShutdownHandlerConcurrentPosts(t *testing.T) {
 	case <-env.shutdownChannel:
 		t.Fatal("expected at most one buffered shutdown signal, got more")
 	default:
+	}
+}
+
+// TestLoadOPAPolicy covers the helper that compiles a rego policy from a
+// (path, query) flag pair. The helper is the single point used by both
+// server (run()) and client (clientBackendDialer()) code paths, so its
+// failure modes are not otherwise exercised by serverListen tests.
+//
+// OPA's file loader supports a "prefix:path" syntax, which means Windows
+// absolute paths (C:\...) get mis-parsed (the drive letter is treated as
+// the prefix). To keep this test cross-platform we chdir into the temp
+// dir and pass relative paths, which contain no ':'.
+func TestLoadOPAPolicy(t *testing.T) {
+	tempDir := t.TempDir()
+
+	const validName = "valid.rego"
+	const garbageName = "garbage.rego"
+
+	if err := os.WriteFile(filepath.Join(tempDir, validName), []byte(`package policy
+import input
+default allow := true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, garbageName), []byte(`this is not valid rego`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(tempDir)
+
+	cases := []struct {
+		name       string
+		path       string
+		query      string
+		wantPolicy bool
+		wantErr    bool
+	}{
+		{"both empty disables OPA", "", "", false, false},
+		{"only path empty disables OPA", "", "data.policy.allow", false, false},
+		{"only query empty disables OPA", validName, "", false, false},
+		{"missing file returns error", "nonexistent.rego", "data.policy.allow", false, true},
+		{"invalid rego returns error", garbageName, "data.policy.allow", false, true},
+		{"valid policy returns non-nil", validName, "data.policy.allow", true, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, err := loadOPAPolicy(c.path, c.query)
+			if c.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, p, "policy must be nil when an error is returned")
+				return
+			}
+			assert.NoError(t, err)
+			if c.wantPolicy {
+				assert.NotNil(t, p, "expected a compiled policy")
+			} else {
+				assert.Nil(t, p, "expected nil policy (OPA disabled)")
+			}
+		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1185,14 +1185,15 @@ func TestUseWorkloadAPIAddrImpliesUseWorkloadAPI(t *testing.T) {
 // TestSignalHandlerReloadAndShutdown lives in unix_test.go because it relies
 // on POSIX signal delivery (SIGHUP) which is unavailable on Windows.
 
-// TestServerListenEarlyErrors covers three early-return failure paths in
+// TestServerListenEarlyErrors covers two early-return failure paths in
 // serverListen that occur before any listener is opened:
 //  1. buildServerConfig fails on a bad cipher suite.
 //  2. wildcard.CompileList fails on an invalid URI pattern.
-//  3. policy.LoadFromPath fails on a missing rego file.
 //
-// All three return before serverListen dereferences env, so a zero-value
-// *Environment is sufficient.
+// Both return before serverListen dereferences env, so a zero-value
+// *Environment is sufficient. The previously-tested policy.LoadFromPath
+// failure path now lives in run() (loaded before serverListen is called),
+// so it is no longer exercised here.
 func TestServerListenEarlyErrors(t *testing.T) {
 	origPolicy := *serverAllowPolicy
 	origQuery := *serverAllowQuery
@@ -1238,25 +1239,13 @@ func TestServerListenEarlyErrors(t *testing.T) {
 			},
 			wantSubstr: "",
 		},
-		{
-			name: "policy load fails",
-			setup: func() {
-				*enabledCipherSuites = "AES,CHACHA"
-				*maxTLSVersion = ""
-				*serverAllowedURIs = nil
-				*serverAllowPolicy = "/nonexistent.rego"
-				*serverAllowQuery = "data.policy.allow"
-				*serverAllowAll = false
-			},
-			wantSubstr: "",
-		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			c.setup()
 			env := &Environment{}
-			err := serverListen(env)
+			err := serverListen(env, nil)
 			assert.NotNil(t, err, "expected non-nil error from serverListen")
 			if c.wantSubstr != "" && err != nil {
 				assert.Contains(t, strings.ToLower(err.Error()), c.wantSubstr)


### PR DESCRIPTION
Moved `policy.LoadFromPath` out of `serverListen` and into `run()` so that `regoPolicy` is set on the Environment struct literal before the timed-reload goroutine starts. Then passed `regoPolicy` into `serverListen` (which still builds the server ACL with it) and removed the racy `env.regoPolicy = regoPolicy` assignment. This mirrors how client mode already constructs the policy via `clientBackendDialer` before the Environment literal.