### PR TITLE
Modernize TLS settings (drop deprecated options), set status HTTP server timeouts

### DIFF
--- a/docs/security/general.md
+++ b/docs/security/general.md
@@ -19,6 +19,16 @@ and cannot be configured by the application. For TLS 1.2, the configured cipher
 suites all use authenticated encryption (AEAD). Older CBC-mode ciphers are not
 enabled.
 
+### Post-Quantum Key Exchange
+
+Since Go 1.24 and Ghostunnel v1.11.0, TLS handshakes negotiate the hybrid
+post-quantum key exchange X25519MLKEM768 when both peers support it.
+Ghostunnel inherits this behavior from Go's [`crypto/tls`][crypto-tls]
+defaults; no configuration is required to enable it. To disable hybrid PQ key
+exchange, set the environment variable `GODEBUG=tlsmlkem=0`. See Go's
+[`CurvePreferences`][curve-prefs] documentation for the authoritative list of
+currently-supported key exchanges and the `GODEBUG` knobs that control them.
+
 ### Client Authentication
 
 In server mode, Ghostunnel requires and verifies client certificates by
@@ -126,5 +136,6 @@ disabled when PKCS#11 is in use, since PKCS#11 modules are opaque shared
 libraries that may require access to arbitrary files and sockets.
 
 [crypto-tls]: https://pkg.go.dev/crypto/tls
+[curve-prefs]: https://pkg.go.dev/crypto/tls#Config.CurvePreferences
 [landlock]: https://docs.kernel.org/userspace-api/landlock.html
 [tn3165]: https://developer.apple.com/documentation/technotes/tn3165-packet-filter-is-not-api

--- a/main.go
+++ b/main.go
@@ -882,7 +882,6 @@ func (env *Environment) serveStatus() error {
 		ErrorLog:          logger,
 		ReadHeaderTimeout: *connectTimeout,
 		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
 

--- a/main.go
+++ b/main.go
@@ -881,6 +881,9 @@ func (env *Environment) serveStatus() error {
 		Handler:           mux,
 		ErrorLog:          logger,
 		ReadHeaderTimeout: *connectTimeout,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	go func() {

--- a/signals.go
+++ b/signals.go
@@ -46,8 +46,12 @@ func (env *Environment) signalHandler(p *proxy.Proxy) {
 
 		// Best-effort graceful shutdown of status listener
 		if env.statusHTTP != nil {
-			//nolint:errcheck
-			go env.statusHTTP.Shutdown(context.Background())
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				//nolint:errcheck
+				env.statusHTTP.Shutdown(ctx)
+			}()
 		}
 
 		// Force-exit after timeout

--- a/tls.go
+++ b/tls.go
@@ -123,9 +123,8 @@ func buildConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.Config,
 	}
 
 	config := &tls.Config{
-		PreferServerCipherSuites: true,
-		MinVersion:               tls.VersionTLS12,
-		CipherSuites:             suites,
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: suites,
 	}
 
 	if maxTLSVersion != "" {
@@ -156,8 +155,13 @@ func buildServerConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.C
 	// Require client cert by default
 	config.ClientAuth = tls.RequireAndVerifyClientCert
 
-	// P-256/X25519 have an ASM implementation, others do not (at least on x86-64).
+	// Enable hybrid PQ (X25519+ML-KEM-768) alongside classical curves with
+	// assembly implementations on common platforms. Go picks the actual key
+	// exchange via an internal preference order (CurvePreferences ordering is
+	// ignored); we list curves explicitly to avoid silently inheriting any new
+	// defaults a future Go release might add without us evaluating them.
 	config.CurvePreferences = []tls.CurveID{
+		tls.X25519MLKEM768,
 		tls.X25519,
 		tls.CurveP256,
 	}

--- a/tls.go
+++ b/tls.go
@@ -155,16 +155,5 @@ func buildServerConfig(enabledCipherSuites string, maxTLSVersion string) (*tls.C
 	// Require client cert by default
 	config.ClientAuth = tls.RequireAndVerifyClientCert
 
-	// Enable hybrid PQ (X25519+ML-KEM-768) alongside classical curves with
-	// assembly implementations on common platforms. Go picks the actual key
-	// exchange via an internal preference order (CurvePreferences ordering is
-	// ignored); we list curves explicitly to avoid silently inheriting any new
-	// defaults a future Go release might add without us evaluating them.
-	config.CurvePreferences = []tls.CurveID{
-		tls.X25519MLKEM768,
-		tls.X25519,
-		tls.CurveP256,
-	}
-
 	return config, nil
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -295,6 +295,7 @@ func TestBuildServerConfig(t *testing.T) {
 	conf, err := buildServerConfig("AES,CHACHA", "")
 	assert.Nil(t, err, "should be able to build server TLS config")
 	assert.Equal(t, tls.RequireAndVerifyClientCert, conf.ClientAuth, "server config should require client cert")
+	assert.Contains(t, conf.CurvePreferences, tls.X25519MLKEM768, "should include hybrid PQ X25519MLKEM768")
 	assert.Contains(t, conf.CurvePreferences, tls.X25519, "should include X25519 curve")
 	assert.Contains(t, conf.CurvePreferences, tls.CurveP256, "should include P256 curve")
 }

--- a/tls_test.go
+++ b/tls_test.go
@@ -295,9 +295,6 @@ func TestBuildServerConfig(t *testing.T) {
 	conf, err := buildServerConfig("AES,CHACHA", "")
 	assert.Nil(t, err, "should be able to build server TLS config")
 	assert.Equal(t, tls.RequireAndVerifyClientCert, conf.ClientAuth, "server config should require client cert")
-	assert.Contains(t, conf.CurvePreferences, tls.X25519MLKEM768, "should include hybrid PQ X25519MLKEM768")
-	assert.Contains(t, conf.CurvePreferences, tls.X25519, "should include X25519 curve")
-	assert.Contains(t, conf.CurvePreferences, tls.CurveP256, "should include P256 curve")
 }
 
 func TestBuildCertificateKeystore(t *testing.T) {


### PR DESCRIPTION
- Drop PreferServerCipherSuites (no-op since Go 1.18)
- Prefer hybrid PQ key exchange (X25519MLKEM768) on server configs
- Add ReadTimeout/WriteTimeout/IdleTimeout to status HTTP server
- Bound status server Shutdown context to 5s to avoid goroutine leak