### PR TITLE
Fix: Better validation for targets and status flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ var (
 	metricsInterval = app.Flag("metrics-interval", "Collect (and post/send) metrics every specified interval.").Default("30s").Duration()
 
 	// Status, logging & other
-	statusAddress  = app.Flag("status", "Enable serving /_status and /_metrics on given HOST:PORT (or unix:SOCKET).").PlaceHolder("ADDR").String()
+	statusAddress  = app.Flag("status", "Enable serving /_status and /_metrics on given [http(s)://]HOST:PORT, unix:PATH, systemd:NAME or launchd:NAME.").PlaceHolder("ADDR").String()
 	enableProf     = app.Flag("enable-pprof", "Enable serving /debug/pprof endpoints alongside /_status (for profiling).").Bool()
 	enableShutdown = app.Flag("enable-shutdown", "Enable serving a /_shutdown endpoint alongside /_status to allow terminating via HTTP POST request.").Default("false").Bool()
 	quiet          = app.Flag("quiet", "Silence log messages (can be all, conns, conn-errs, handshake-errs; repeat flag for more than one)").Default("").Enums("", "all", "conns", "handshake-errs", "conn-errs")
@@ -261,8 +261,30 @@ func validateFlags(app *kingpin.Application) error {
 	if *serverStatusTargetAddress != "" && !strings.HasPrefix(*serverStatusTargetAddress, "http://") && !strings.HasPrefix(*serverStatusTargetAddress, "https://") {
 		return fmt.Errorf("--target-status should start with http:// or https://")
 	}
+	if err := validateStatusAddress(); err != nil {
+		return err
+	}
 	if *connectTimeout == 0 {
 		return fmt.Errorf("--connect-timeout duration must not be zero")
+	}
+	return nil
+}
+
+// validateStatusAddress enforces the supported shapes of --status: TLS may
+// only be served on TCP, so the http:// and https:// scheme prefixes are
+// rejected for unix/systemd/launchd listeners (which always serve plain HTTP).
+func validateStatusAddress() error {
+	if *statusAddress == "" {
+		return nil
+	}
+	_, addr := socket.ParseHTTPAddress(*statusAddress)
+	network, _, _, err := socket.ParseAddress(addr, true)
+	if err != nil {
+		return fmt.Errorf("invalid --status address: %w", err)
+	}
+	hasScheme := strings.HasPrefix(*statusAddress, "http://") || strings.HasPrefix(*statusAddress, "https://")
+	if hasScheme && network != "tcp" {
+		return fmt.Errorf("invalid --status network %q: http(s):// scheme requires a HOST:PORT target", network)
 	}
 	return nil
 }
@@ -913,7 +935,7 @@ func (env *Environment) serveStatus() error {
 		return err
 	}
 
-	if network != "unix" && https && env.tlsConfigSource.CanServe() {
+	if network == "tcp" && https && env.tlsConfigSource.CanServe() {
 		config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -204,8 +204,10 @@ var exitFunc = os.Exit
 
 // extraRWPaths collects additional filesystem paths that should be
 // read-writable under landlock. Populated by init() hooks (e.g. the
-// coverage build tag registers GOCOVERDIR here).
-var extraRWPaths []string
+// coverage build tag registers GOCOVERDIR here) and consumed by the
+// linux landlock setup. Read/written only behind build tags, hence the
+// nolint directive.
+var extraRWPaths []string //nolint:unused
 
 // Environment groups listening context data together.
 type Environment struct {

--- a/main.go
+++ b/main.go
@@ -344,6 +344,13 @@ func validateServerTarget() error {
 	if !*serverUnsafeTarget && !consideredSafe(*serverForwardAddress) {
 		return errors.New("--target must be unix:PATH or localhost:PORT (unless --unsafe-target is set)")
 	}
+	network, _, _, err := socket.ParseAddress(*serverForwardAddress, true)
+	if err != nil {
+		return fmt.Errorf("invalid --target address: %w", err)
+	}
+	if !socket.IsDialableNetwork(network) {
+		return fmt.Errorf("invalid --target network %q: only tcp and unix targets are supported (systemd:/launchd: cannot be dialed)", network)
+	}
 	return nil
 }
 
@@ -439,6 +446,17 @@ func validateClientListen() error {
 	return nil
 }
 
+func validateClientTarget() error {
+	network, _, _, err := socket.ParseAddress(*clientForwardAddress, true)
+	if err != nil {
+		return fmt.Errorf("invalid --target address: %w", err)
+	}
+	if network != "tcp" {
+		return fmt.Errorf("invalid --target network %q: client mode requires a HOST:PORT TCP target", network)
+	}
+	return nil
+}
+
 func validateClientOPA() error {
 	hasOPAFlags := len(*clientAllowPolicy) > 0 || len(*clientAllowQuery) > 0
 	if !hasOPAFlags {
@@ -456,6 +474,9 @@ func clientValidateFlags() error {
 		return err
 	}
 	if err := validateClientListen(); err != nil {
+		return err
+	}
+	if err := validateClientTarget(); err != nil {
 		return err
 	}
 	if err := validateClientOPA(); err != nil {
@@ -929,14 +950,6 @@ func serverBackendDialer() (proxy.DialFunc, error) {
 	backendNet, backendAddr, _, err := socket.ParseAddress(*serverForwardAddress, *skipResolve)
 	if err != nil {
 		return nil, err
-	}
-
-	// Socket-activation networks ("systemd"/"launchd") only make sense for
-	// listening, not dialing. net.Dialer cannot dial them, so reject these
-	// targets at startup with a clear error rather than failing on every
-	// connection with "dial systemd: unknown network systemd".
-	if backendNet != "tcp" && backendNet != "unix" {
-		return nil, fmt.Errorf("invalid --target network %q: only tcp and unix targets are supported (systemd:/launchd: cannot be dialed)", backendNet)
 	}
 
 	return func(ctx context.Context) (net.Conn, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -541,6 +541,44 @@ func TestValidateServerTargetRejectsMalformed(t *testing.T) {
 	}
 }
 
+func TestValidateStatusAddress(t *testing.T) {
+	original := *statusAddress
+	defer func() { *statusAddress = original }()
+
+	cases := []struct {
+		input     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{input: "", wantErr: false},
+		{input: "localhost:8080", wantErr: false},
+		{input: "http://localhost:8080", wantErr: false},
+		{input: "https://localhost:8080", wantErr: false},
+		{input: "unix:/tmp/foo", wantErr: false},
+		{input: "systemd:status", wantErr: false},
+		{input: "launchd:status", wantErr: false},
+		{input: "http://unix:/tmp/foo", wantErr: true, errSubstr: "unix"},
+		{input: "http://systemd:status", wantErr: true, errSubstr: "systemd"},
+		{input: "http://launchd:status", wantErr: true, errSubstr: "launchd"},
+		{input: "https://unix:/tmp/foo", wantErr: true, errSubstr: "unix"},
+		{input: "https://systemd:status", wantErr: true, errSubstr: "systemd"},
+		{input: "https://launchd:status", wantErr: true, errSubstr: "launchd"},
+		{input: "garbage", wantErr: true},
+	}
+	for _, c := range cases {
+		*statusAddress = c.input
+		err := validateStatusAddress()
+		if c.wantErr {
+			assert.NotNil(t, err, "input %q should be rejected", c.input)
+			if err != nil && c.errSubstr != "" {
+				assert.Contains(t, err.Error(), c.errSubstr, "error for %q should mention %q", c.input, c.errSubstr)
+			}
+		} else {
+			assert.Nil(t, err, "input %q should be accepted", c.input)
+		}
+	}
+}
+
 
 func TestInvalidCABundle(t *testing.T) {
 	cmd := []string{

--- a/main_test.go
+++ b/main_test.go
@@ -373,6 +373,7 @@ func TestClientFlagValidation(t *testing.T) {
 	// Test: OPA flags must be used together
 	*keystorePath = "file"
 	*clientListenAddress = "127.0.0.1:8080"
+	*clientForwardAddress = "localhost:8443"
 	*enabledCipherSuites = "AES,CHACHA"
 
 	*clientAllowPolicy = "policy"
@@ -423,28 +424,36 @@ func TestServerBackendDialerError(t *testing.T) {
 	assert.NotNil(t, err, "invalid forward address should not have dialer")
 }
 
-func TestServerBackendDialerRejectsSystemd(t *testing.T) {
+func TestValidateServerTargetRejectsSystemd(t *testing.T) {
 	original := *serverForwardAddress
 	defer func() { *serverForwardAddress = original }()
 
 	*serverForwardAddress = "systemd:foo"
-	_, err := serverBackendDialer()
-	assert.NotNil(t, err, "systemd: target should be rejected at startup")
+	err := validateServerTarget()
+	assert.NotNil(t, err, "systemd: target should be rejected")
 	if err != nil {
 		assert.Contains(t, err.Error(), "systemd", "error message should mention the offending network")
 	}
 }
 
-func TestServerBackendDialerRejectsLaunchd(t *testing.T) {
+func TestValidateServerTargetRejectsLaunchd(t *testing.T) {
 	original := *serverForwardAddress
 	defer func() { *serverForwardAddress = original }()
 
 	*serverForwardAddress = "launchd:foo"
-	_, err := serverBackendDialer()
-	assert.NotNil(t, err, "launchd: target should be rejected at startup")
+	err := validateServerTarget()
+	assert.NotNil(t, err, "launchd: target should be rejected")
 	if err != nil {
 		assert.Contains(t, err.Error(), "launchd", "error message should mention the offending network")
 	}
+}
+
+func TestValidateServerTargetAcceptsUnix(t *testing.T) {
+	original := *serverForwardAddress
+	defer func() { *serverForwardAddress = original }()
+
+	*serverForwardAddress = "unix:/tmp/ghostunnel-target-test.sock"
+	assert.Nil(t, validateServerTarget(), "unix: target should be accepted")
 }
 
 func TestServerBackendDialerAcceptsUnix(t *testing.T) {
@@ -456,6 +465,82 @@ func TestServerBackendDialerAcceptsUnix(t *testing.T) {
 	assert.Nil(t, err, "unix: target should be accepted")
 	assert.NotNil(t, dial, "unix: target should produce a dialer")
 }
+
+func TestValidateClientTargetRejectsUnix(t *testing.T) {
+	original := *clientForwardAddress
+	defer func() { *clientForwardAddress = original }()
+
+	*clientForwardAddress = "unix:/tmp/foo"
+	err := validateClientTarget()
+	assert.NotNil(t, err, "unix: target should be rejected for client mode")
+	if err != nil {
+		assert.Contains(t, err.Error(), "unix", "error message should mention the offending network")
+	}
+}
+
+func TestValidateClientTargetRejectsSystemd(t *testing.T) {
+	original := *clientForwardAddress
+	defer func() { *clientForwardAddress = original }()
+
+	*clientForwardAddress = "systemd:foo"
+	err := validateClientTarget()
+	assert.NotNil(t, err, "systemd: target should be rejected for client mode")
+	if err != nil {
+		assert.Contains(t, err.Error(), "systemd", "error message should mention the offending network")
+	}
+}
+
+func TestValidateClientTargetRejectsLaunchd(t *testing.T) {
+	original := *clientForwardAddress
+	defer func() { *clientForwardAddress = original }()
+
+	*clientForwardAddress = "launchd:foo"
+	err := validateClientTarget()
+	assert.NotNil(t, err, "launchd: target should be rejected for client mode")
+	if err != nil {
+		assert.Contains(t, err.Error(), "launchd", "error message should mention the offending network")
+	}
+}
+
+func TestValidateClientTargetAcceptsTCP(t *testing.T) {
+	original := *clientForwardAddress
+	defer func() { *clientForwardAddress = original }()
+
+	*clientForwardAddress = "localhost:8443"
+	assert.Nil(t, validateClientTarget(), "localhost:PORT target should be accepted for client mode")
+}
+
+func TestValidateClientTargetRejectsMalformed(t *testing.T) {
+	original := *clientForwardAddress
+	defer func() { *clientForwardAddress = original }()
+
+	*clientForwardAddress = "no-port-here"
+	err := validateClientTarget()
+	assert.NotNil(t, err, "malformed target should be rejected")
+	if err != nil {
+		assert.Contains(t, err.Error(), "invalid --target address", "error should identify the bad flag")
+	}
+}
+
+func TestValidateServerTargetRejectsMalformed(t *testing.T) {
+	originalAddr := *serverForwardAddress
+	originalUnsafe := *serverUnsafeTarget
+	defer func() {
+		*serverForwardAddress = originalAddr
+		*serverUnsafeTarget = originalUnsafe
+	}()
+
+	// --unsafe-target bypasses the consideredSafe gate so the parse path
+	// runs on a malformed input.
+	*serverUnsafeTarget = true
+	*serverForwardAddress = "no-port-here"
+	err := validateServerTarget()
+	assert.NotNil(t, err, "malformed target should be rejected even with --unsafe-target")
+	if err != nil {
+		assert.Contains(t, err.Error(), "invalid --target address", "error should identify the bad flag")
+	}
+}
+
 
 func TestInvalidCABundle(t *testing.T) {
 	cmd := []string{

--- a/socket/net.go
+++ b/socket/net.go
@@ -61,6 +61,13 @@ func ParseAddress(input string, skipResolve bool) (network, address, host string
 	return
 }
 
+// IsDialableNetwork reports whether the network returned by ParseAddress
+// can be opened by net.Dialer. The "systemd" and "launchd" networks are
+// listen-only schemes for socket activation and cannot be dialed.
+func IsDialableNetwork(network string) bool {
+	return network == "tcp" || network == "unix"
+}
+
 // ParseHTTPAddress parses a string representing a TCP address or HTTP/HTTPS address
 // If the input is HTTP/HTTPS, return address will strip away the prefix
 // Otherwise, return address will be same as input

--- a/socket/net_test.go
+++ b/socket/net_test.go
@@ -82,6 +82,14 @@ func TestParseAddress(t *testing.T) {
 	assert.NotNil(t, err, "was able to parse invalid host/port")
 }
 
+func TestIsDialableNetwork(t *testing.T) {
+	assert.True(t, IsDialableNetwork("tcp"), "tcp must be dialable")
+	assert.True(t, IsDialableNetwork("unix"), "unix must be dialable")
+	assert.False(t, IsDialableNetwork("systemd"), "systemd is listen-only")
+	assert.False(t, IsDialableNetwork("launchd"), "launchd is listen-only")
+	assert.False(t, IsDialableNetwork(""), "empty network must not be dialable")
+}
+
 func TestParseHTTPAddress(t *testing.T) {
 	https, address := ParseHTTPAddress("http://localhost")
 	if https != false {


### PR DESCRIPTION
Two changes:
- Reject https:// on non-TCP --status listeners. This was oddly kind of supported before, but not consistently and correctly, so we tighten this up to make it clear what is or isn't supported. 
- Reject undialable --target networks at flag validation. This would already fail later on, but better to handle it up front with clearer error messages. 