### PR TITLE
Fix service name plumbing for Windows SCM / event log

### DIFF
--- a/docs/deployment/windows-service.md
+++ b/docs/deployment/windows-service.md
@@ -88,7 +88,10 @@ Get-WinEvent -FilterHashtable @{LogName='Application'; ProviderName='ghostunnel'
 ```
 
 The `--eventlog` flag also works when running Ghostunnel interactively
-(outside of a service), though this is less common.
+(outside of a service), though this is less common. In that mode the source
+defaults to `ghostunnel`, which must already be registered with the Event Log
+(for example, by a prior `ghostunnel service install`) or Event Viewer will
+display "*The description for Event ID … cannot be found.*" for each entry.
 
 ## Subcommand Reference
 

--- a/windows.go
+++ b/windows.go
@@ -35,6 +35,16 @@ var (
 	// serviceStopCh is written to by the Windows Service Control Manager stop
 	// handler to trigger a graceful shutdown of the running proxy.
 	serviceStopCh = make(chan bool, 1)
+
+	// serviceLogSource is the Event Log source name used by --eventlog. It
+	// defaults to defaultServiceName so interactive invocations log to the
+	// same source the default service install registers. runAsService
+	// overrides it with the SCM-discovered name before svc.Run dispatches, so
+	// runtime entries land on the source that doInstallService registered at
+	// install time. The send/receive inside svc.Run establishes the
+	// happens-before for the run() goroutine that later reads it from
+	// initSystemLogger.
+	serviceLogSource = defaultServiceName
 )
 
 func useSystemLog() bool {
@@ -72,7 +82,7 @@ func (w *eventLogWriter) Close() error {
 }
 
 func initSystemLogger() error {
-	w, err := newEventLogWriter("ghostunnel")
+	w, err := newEventLogWriter(serviceLogSource)
 	if err != nil {
 		return err
 	}
@@ -95,6 +105,6 @@ func isRunningAsService() bool {
 
 // runAsService hands control to the Windows Service Control Manager.
 func runAsService() {
-	name := currentServiceName()
-	_ = svc.Run(name, &ghostunnelService{name: name})
+	serviceLogSource = currentServiceName()
+	_ = svc.Run(serviceLogSource, &ghostunnelService{name: serviceLogSource})
 }

--- a/windows.go
+++ b/windows.go
@@ -39,11 +39,11 @@ var (
 	// serviceLogSource is the Event Log source name used by --eventlog. It
 	// defaults to defaultServiceName so interactive invocations log to the
 	// same source the default service install registers. runAsService
-	// overrides it with the SCM-discovered name before svc.Run dispatches, so
+	// overrides it with the SCM-discovered name before calling svc.Run, so
 	// runtime entries land on the source that doInstallService registered at
-	// install time. The send/receive inside svc.Run establishes the
-	// happens-before for the run() goroutine that later reads it from
-	// initSystemLogger.
+	// install time. svc.Run starts the service handler goroutine after this
+	// assignment, so initSystemLogger (called from run()) observes the updated
+	// value.
 	serviceLogSource = defaultServiceName
 )
 

--- a/windows_test.go
+++ b/windows_test.go
@@ -35,3 +35,23 @@ func TestInitSystemLogger(t *testing.T) {
 	assert.NotEqual(t, originalLogger, logger, "logger should be updated")
 	assert.NotNil(t, logger)
 }
+
+// TestInitSystemLoggerUsesServiceLogSource verifies that initSystemLogger opens
+// the Event Log source named by serviceLogSource — the variable runAsService
+// seeds with the SCM-registered service name — rather than a hardcoded source.
+func TestInitSystemLoggerUsesServiceLogSource(t *testing.T) {
+	originalLogger := logger
+	originalSource := serviceLogSource
+	t.Cleanup(func() {
+		logger = originalLogger
+		serviceLogSource = originalSource
+	})
+
+	// "Application" is a built-in Event Log that is always registerable as an
+	// event source, so the test doesn't depend on prior service installation.
+	serviceLogSource = "Application"
+	if err := initSystemLogger(); err != nil {
+		t.Fatalf("initSystemLogger with serviceLogSource=%q failed: %s", serviceLogSource, err)
+	}
+	assert.NotEqual(t, originalLogger, logger, "logger should be updated")
+}


### PR DESCRIPTION
Fix service name plumbing for Windows SCM / event log: We should write to the event log matching the current service name, which isn't always "ghostunnel". 