### PR TITLE
Proper error handling for SCM svcRun failures

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 
@@ -103,8 +104,28 @@ func isRunningAsService() bool {
 	return err == nil && ok
 }
 
-// runAsService hands control to the Windows Service Control Manager.
+// svcRun is the SCM dispatcher entry point. A package-level indirection so
+// tests can simulate dispatcher failures without invoking the real
+// StartServiceCtrlDispatcher (which only succeeds when the process was
+// launched by the SCM). currentServiceName, called from runAsService just
+// above this, still issues a best-effort mgr.Connect and gracefully falls
+// back to defaultServiceName when the SCM is unavailable.
+var svcRun = svc.Run
+
+// runAsService hands control to the Windows Service Control Manager and
+// returns when the dispatcher exits. A non-nil error from svcRun means
+// StartServiceCtrlDispatcher itself failed (rare; e.g. SCM transient or
+// malformed name pointer) — never an error reported by Execute, which the
+// dispatcher conveys to SCM via the SERVICE_STATUS struct. We surface the
+// failure to the Event Log (best-effort), stderr (null under SCM but useful
+// for manual repro), and process exit code so the services console shows a
+// non-zero ExitCode instead of a silent 0.
 func runAsService() {
 	serviceLogSource = currentServiceName()
-	_ = svc.Run(serviceLogSource, &ghostunnelService{name: serviceLogSource})
+	if err := svcRun(serviceLogSource, &ghostunnelService{name: serviceLogSource}); err != nil {
+		msg := fmt.Sprintf("ghostunnel SCM dispatcher failed: %v", err)
+		writeEventLogError(serviceLogSource, msg)
+		fmt.Fprintln(os.Stderr, "error: "+msg)
+		exitFunc(1)
+	}
 }

--- a/windows_test.go
+++ b/windows_test.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows/svc"
 )
 
 func TestUseSystemLog(t *testing.T) {
@@ -34,6 +36,53 @@ func TestInitSystemLogger(t *testing.T) {
 	}
 	assert.NotEqual(t, originalLogger, logger, "logger should be updated")
 	assert.NotNil(t, logger)
+}
+
+// TestRunAsServiceSurfacesDispatcherError verifies that a non-nil error from
+// the SCM dispatcher results in a non-zero exit via exitFunc, rather than
+// being silently swallowed. The svcRun seam avoids invoking the real
+// StartServiceCtrlDispatcher; currentServiceName still runs but falls back
+// gracefully when the SCM cannot be reached.
+func TestRunAsServiceSurfacesDispatcherError(t *testing.T) {
+	origRun := svcRun
+	origExit := exitFunc
+	origSource := serviceLogSource
+	t.Cleanup(func() {
+		svcRun = origRun
+		exitFunc = origExit
+		serviceLogSource = origSource
+	})
+
+	exitCode := -1
+	exitFunc = func(c int) { exitCode = c }
+	svcRun = func(string, svc.Handler) error {
+		return errors.New("scripted dispatch failure")
+	}
+
+	runAsService()
+
+	assert.Equal(t, 1, exitCode, "exitFunc should be called with 1 on dispatcher failure")
+}
+
+// TestRunAsServiceSilentOnSuccess verifies the success path leaves exitFunc
+// uncalled, so main() returns 0 the normal way.
+func TestRunAsServiceSilentOnSuccess(t *testing.T) {
+	origRun := svcRun
+	origExit := exitFunc
+	origSource := serviceLogSource
+	t.Cleanup(func() {
+		svcRun = origRun
+		exitFunc = origExit
+		serviceLogSource = origSource
+	})
+
+	exitCalled := false
+	exitFunc = func(int) { exitCalled = true }
+	svcRun = func(string, svc.Handler) error { return nil }
+
+	runAsService()
+
+	assert.False(t, exitCalled, "exitFunc must not be called when svcRun succeeds")
 }
 
 // TestInitSystemLoggerUsesServiceLogSource verifies that initSystemLogger opens


### PR DESCRIPTION
Proper error handling for SCM svcRun failures. This shouldn't happen in practice, but if it does, we want to log it. 