### PR TITLE
Handle shutdown in SCM code better

### DIFF
--- a/tests/test-service-scm-graceful-shutdown.py
+++ b/tests/test-service-scm-graceful-shutdown.py
@@ -30,7 +30,7 @@ import threading
 import time
 
 from common import (LOCALHOST, LISTEN_PORT, TARGET_PORT,
-                    RootCert, SocketPair, TcpServer, TlsClient,
+                    SocketPair, TcpServer, TlsClient,
                     create_default_certs, print_ok, require_admin,
                     require_platform, run_ghostunnel)
 
@@ -141,9 +141,9 @@ try:
     pair.validate_can_send_from_server("world", "send after SCM Stop, mid-drain")
     pair.validate_closing_client_closes_server("drain completes")
 
-    stop_thread.join(timeout=60)
+    stop_thread.join(timeout=90)
     if stop_thread.is_alive():
-        raise Exception("'service stop' did not return within 60s")
+        raise Exception("'service stop' did not return within 90s")
 
     if 'exc' in stop_result:
         raise Exception("'service stop' raised: {0}".format(stop_result['exc']))

--- a/tests/test-service-scm-graceful-shutdown.py
+++ b/tests/test-service-scm-graceful-shutdown.py
@@ -29,7 +29,7 @@ import sys
 import threading
 import time
 
-from common import (LOCALHOST, LISTEN_PORT, TARGET_PORT,
+from common import (LOCALHOST, LISTEN_PORT, STATUS_PORT, TARGET_PORT,
                     SocketPair, TcpServer, TlsClient,
                     create_default_certs, print_ok, require_admin,
                     require_platform, run_ghostunnel)
@@ -92,6 +92,7 @@ try:
         '--', 'server',
         '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
         '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
+        '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT),
         '--keystore={0}'.format(keystore),
         '--cacert={0}'.format(cacert),
         '--allow-ou=client',

--- a/tests/test-service-scm-graceful-shutdown.py
+++ b/tests/test-service-scm-graceful-shutdown.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+"""
+Tests graceful shutdown via the Windows SCM Stop path (not /_shutdown, which
+test-service-graceful-shutdown.py already covers).
+
+Why this exists: when the SCM stops a service, Execute is responsible for
+sending periodic StopPending CheckPoint/WaitHint updates while the proxy
+drains. Without them, the SCM may conclude the service is hung after
+ServicesPipeTimeout (~30s default) and forcibly terminate the process,
+truncating the drain and defeating the documented graceful-stop behavior.
+
+Test design:
+  1. Install a service with a long --shutdown-timeout so the drain has time
+     to outlast a couple of progress ticks.
+  2. Open an in-flight TLS connection through the proxy.
+  3. Trigger 'ghostunnel service stop' on a background thread (the call
+     blocks until SCM observes Stopped).
+  4. Verify the connection's tail bytes still flow, then close it.
+  5. Verify SCM reports Stopped, the service process exited cleanly, and
+     the stop command returned success.
+
+Requires Windows and Administrator privileges.
+"""
+
+import os
+import subprocess
+import sys
+import threading
+import time
+
+from common import (LOCALHOST, LISTEN_PORT, TARGET_PORT,
+                    RootCert, SocketPair, TcpServer, TlsClient,
+                    create_default_certs, print_ok, require_admin,
+                    require_platform, run_ghostunnel)
+
+require_platform('Windows')
+require_admin()
+
+SERVICE_NAME = 'ghostunnel-pytest-scm-drain'
+
+# Long enough that the StopPending wait outlasts at least one
+# progressTickInterval (5s) and matches the kind of real drain SCM would
+# otherwise time out on. Short enough to keep the test from dragging.
+SHUTDOWN_TIMEOUT = '20s'
+CLOSE_TIMEOUT = '20s'
+
+root = None
+
+
+def run_service_cmd(args, timeout=60):
+    proc = run_ghostunnel(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate(timeout=timeout)
+    return proc.returncode, stdout.decode(), stderr.decode()
+
+
+def uninstall_quietly():
+    try:
+        proc = run_ghostunnel(
+            ['service', 'uninstall', '--service-name', SERVICE_NAME],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc.communicate(timeout=30)
+    except Exception:
+        pass
+
+
+def service_pid():
+    """Return the SCM-reported PID for SERVICE_NAME, or 0 if stopped/missing."""
+    ps_cmd = (
+        "$ErrorActionPreference='SilentlyContinue'; "
+        "(Get-CimInstance Win32_Service -Filter \"Name='{0}'\").ProcessId"
+    ).format(SERVICE_NAME)
+    ps = subprocess.run(
+        ['powershell.exe', '-NoProfile', '-Command', ps_cmd],
+        capture_output=True, text=True, timeout=15)
+    out = (ps.stdout or '').strip()
+    try:
+        return int(out) if out else 0
+    except ValueError:
+        return 0
+
+
+try:
+    root = create_default_certs()
+    keystore = os.path.abspath('server.p12')
+    cacert = os.path.abspath('root.crt')
+
+    uninstall_quietly()
+
+    rc, stdout, stderr = run_service_cmd([
+        'service', 'install', '--service-name', SERVICE_NAME,
+        '--', 'server',
+        '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+        '--target={0}:{1}'.format(LOCALHOST, TARGET_PORT),
+        '--keystore={0}'.format(keystore),
+        '--cacert={0}'.format(cacert),
+        '--allow-ou=client',
+        '--shutdown-timeout={0}'.format(SHUTDOWN_TIMEOUT),
+        '--close-timeout={0}'.format(CLOSE_TIMEOUT),
+    ])
+    if rc != 0:
+        print("install failed:\nstdout: {0}\nstderr: {1}".format(
+            stdout, stderr), file=sys.stderr)
+        raise Exception("service install failed (rc={0})".format(rc))
+    print_ok("install: OK")
+
+    pid_before = service_pid()
+    if pid_before == 0:
+        raise Exception("SCM reports the service has no PID after install")
+    print_ok("service running as PID {0}".format(pid_before))
+
+    # Establish an in-flight connection before SCM Stop.
+    pair = SocketPair(
+        TlsClient('client', 'root', LISTEN_PORT), TcpServer(TARGET_PORT))
+    pair.validate_can_send_from_client("hello", "send before SCM Stop")
+
+    # Trigger 'ghostunnel service stop' on a background thread. It blocks
+    # until SCM sees Stopped (waitForServiceRunningStopped polls), which
+    # is what makes the periodic StopPending CheckPoint updates necessary.
+    stop_result = {}
+
+    def do_stop():
+        try:
+            stop_result['rc'], stop_result['out'], stop_result['err'] = run_service_cmd(
+                ['service', 'stop', '--service-name', SERVICE_NAME],
+                timeout=90)
+        except Exception as exc:
+            stop_result['exc'] = repr(exc)
+
+    stop_thread = threading.Thread(target=do_stop)
+    stop_thread.start()
+
+    # Give the SCM a moment to enter StopPending before draining the
+    # in-flight connection. Slow enough that at least one progress tick
+    # fires before drain completes.
+    time.sleep(7)
+
+    # The in-flight connection must still flow after StopPending. If SCM
+    # had killed the process, validate_can_send_from_server would fail
+    # with a connection error.
+    pair.validate_can_send_from_server("world", "send after SCM Stop, mid-drain")
+    pair.validate_closing_client_closes_server("drain completes")
+
+    stop_thread.join(timeout=60)
+    if stop_thread.is_alive():
+        raise Exception("'service stop' did not return within 60s")
+
+    if 'exc' in stop_result:
+        raise Exception("'service stop' raised: {0}".format(stop_result['exc']))
+    if stop_result.get('rc', 1) != 0:
+        raise Exception("'service stop' returned rc={0}:\n{1}\n{2}".format(
+            stop_result.get('rc'), stop_result.get('out'), stop_result.get('err')))
+    print_ok("'service stop' returned 0")
+
+    if service_pid() != 0:
+        raise Exception("SCM still reports a PID for the service after stop")
+    print_ok("SCM reports service stopped")
+
+    print_ok("OK")
+finally:
+    uninstall_quietly()
+    if root:
+        root.cleanup()

--- a/windows_service.go
+++ b/windows_service.go
@@ -46,6 +46,18 @@ const (
 	// waiting for a state transition.
 	serviceStatePollInterval = 300 * time.Millisecond
 
+	// progressTickInterval is how often Execute pushes a CheckPoint update to
+	// SCM during StartPending and StopPending transitions, so SCM treats the
+	// service as making progress rather than hanging. The Windows SCM kills
+	// services that don't transition to a terminal state or report progress
+	// within ServicesPipeTimeout (~30s by default).
+	progressTickInterval = 5 * time.Second
+	// progressWaitHintMs is the WaitHint (in milliseconds) sent with each
+	// progress update: SCM treats this as how long to wait before considering
+	// the service unresponsive. Set to 3x progressTickInterval so a tick can
+	// arrive late without SCM declaring the service hung.
+	progressWaitHintMs = uint32(15_000)
+
 	// failedToStartMsg is the format string used whenever a service does not
 	// reach Running, regardless of which terminal state was observed. The
 	// Event Log is the source of truth for the underlying cause.
@@ -159,7 +171,7 @@ func (s *ghostunnelService) Execute(args []string, r <-chan svc.ChangeRequest, c
 		defer elog.Close()
 	}
 
-	changes <- svc.Status{State: svc.StartPending}
+	changes <- svc.Status{State: svc.StartPending, CheckPoint: 1, WaitHint: progressWaitHintMs}
 
 	done := make(chan error, 1)
 	go func() {
@@ -168,27 +180,42 @@ func (s *ghostunnelService) Execute(args []string, r <-chan svc.ChangeRequest, c
 
 	// Defer the Running transition until the proxy actually starts listening
 	// (signaled via notifyServiceReady, called from statusHandler.Listening).
-	// If run() exits early or never reaches ready, fail the start.
-	select {
-	case <-serviceReadyCh:
-		changes <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
-		if elog != nil {
-			_ = elog.Info(1, "ghostunnel service started")
-		}
-	case err := <-done:
-		if elog != nil {
-			msg := "ghostunnel exited before reaching ready"
-			if err != nil {
-				msg = fmt.Sprintf("%s: %v", msg, err)
+	// If run() exits early or never reaches ready, fail the start. Tick a
+	// periodic CheckPoint update so the SCM doesn't conclude we're hung
+	// during legitimately slow startup (e.g. PKCS#11/HSM probing).
+	startDeadline := time.After(serviceStateChangeTimeout)
+	startTicker := time.NewTicker(progressTickInterval)
+	startCheckpoint := uint32(1)
+startupWait:
+	for {
+		select {
+		case <-serviceReadyCh:
+			startTicker.Stop()
+			changes <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
+			if elog != nil {
+				_ = elog.Info(1, "ghostunnel service started")
 			}
-			_ = elog.Error(1, msg)
+			break startupWait
+		case err := <-done:
+			startTicker.Stop()
+			if elog != nil {
+				msg := "ghostunnel exited before reaching ready"
+				if err != nil {
+					msg = fmt.Sprintf("%s: %v", msg, err)
+				}
+				_ = elog.Error(1, msg)
+			}
+			return false, 1
+		case <-startDeadline:
+			startTicker.Stop()
+			if elog != nil {
+				_ = elog.Error(1, "ghostunnel did not reach ready state within timeout")
+			}
+			return false, 1
+		case <-startTicker.C:
+			startCheckpoint++
+			changes <- svc.Status{State: svc.StartPending, CheckPoint: startCheckpoint, WaitHint: progressWaitHintMs}
 		}
-		return false, 1
-	case <-time.After(serviceStateChangeTimeout):
-		if elog != nil {
-			_ = elog.Error(1, "ghostunnel did not reach ready state within timeout")
-		}
-		return false, 1
 	}
 
 	for {
@@ -208,7 +235,7 @@ func (s *ghostunnelService) Execute(args []string, r <-chan svc.ChangeRequest, c
 			case svc.Interrogate:
 				changes <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
-				changes <- svc.Status{State: svc.StopPending}
+				changes <- svc.Status{State: svc.StopPending, CheckPoint: 1, WaitHint: progressWaitHintMs}
 				if elog != nil {
 					_ = elog.Info(1, "ghostunnel service stopping")
 				}
@@ -216,8 +243,23 @@ func (s *ghostunnelService) Execute(args []string, r <-chan svc.ChangeRequest, c
 				case serviceStopCh <- true:
 				default:
 				}
-				<-done // wait for graceful drain to complete
-				return false, 0
+				// Tick periodic CheckPoint updates so the SCM doesn't conclude
+				// the service is hung during a long drain. shutdownTimeout
+				// defaults to 5m; without these updates SCM may forcibly
+				// terminate the service after ServicesPipeTimeout (~30s),
+				// defeating the documented graceful-drain behavior.
+				stopTicker := time.NewTicker(progressTickInterval)
+				stopCheckpoint := uint32(1)
+				for {
+					select {
+					case <-done:
+						stopTicker.Stop()
+						return false, 0
+					case <-stopTicker.C:
+						stopCheckpoint++
+						changes <- svc.Status{State: svc.StopPending, CheckPoint: stopCheckpoint, WaitHint: progressWaitHintMs}
+					}
+				}
 			}
 		}
 	}

--- a/windows_service.go
+++ b/windows_service.go
@@ -54,9 +54,11 @@ const (
 	progressTickInterval = 5 * time.Second
 	// progressWaitHintMs is the WaitHint (in milliseconds) sent with each
 	// progress update: SCM treats this as how long to wait before considering
-	// the service unresponsive. Set to 3x progressTickInterval so a tick can
-	// arrive late without SCM declaring the service hung.
-	progressWaitHintMs = uint32(15_000)
+	// the service unresponsive. Derived as 3x progressTickInterval so a tick
+	// can arrive late without SCM declaring the service hung; keeping the
+	// expression rather than a hardcoded literal avoids drift if the tick
+	// interval is ever retuned.
+	progressWaitHintMs = uint32(3 * progressTickInterval / time.Millisecond)
 
 	// failedToStartMsg is the format string used whenever a service does not
 	// reach Running, regardless of which terminal state was observed. The
@@ -215,6 +217,16 @@ startupWait:
 		case <-startTicker.C:
 			startCheckpoint++
 			changes <- svc.Status{State: svc.StartPending, CheckPoint: startCheckpoint, WaitHint: progressWaitHintMs}
+		case c := <-r:
+			// Drain r so svc.serviceMain (unbuffered cmdsToHandler) doesn't
+			// block the SCM callback path during startup. Stop/Shutdown can't
+			// arrive here because the Running status (which advertises
+			// Accepts: Stop|Shutdown) hasn't been sent yet, but Interrogate
+			// has no Accepts gate and may fire from services.msc or SCM
+			// monitoring.
+			if c.Cmd == svc.Interrogate {
+				changes <- svc.Status{State: svc.StartPending, CheckPoint: startCheckpoint, WaitHint: progressWaitHintMs}
+			}
 		}
 	}
 
@@ -258,6 +270,15 @@ startupWait:
 					case <-stopTicker.C:
 						stopCheckpoint++
 						changes <- svc.Status{State: svc.StopPending, CheckPoint: stopCheckpoint, WaitHint: progressWaitHintMs}
+					case c := <-r:
+						// Drain r so svc.serviceMain (unbuffered
+						// cmdsToHandler) doesn't block the SCM callback path
+						// during a long drain. Interrogate re-emits the
+						// current StopPending status; redundant Stop/Shutdown
+						// commands are no-ops because we're already stopping.
+						if c.Cmd == svc.Interrogate {
+							changes <- svc.Status{State: svc.StopPending, CheckPoint: stopCheckpoint, WaitHint: progressWaitHintMs}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Handle shutdown in SCM code better. Need to set checkpoints so we don't freeze when there's a long shutdown timeout set, higher than what Windows/SCM considers normal. 