### PR TITLE
Small perf improvements in hot path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,12 @@ version: "2"
 linters:
   # Use default linters (errcheck, govet, ineffassign, staticcheck, unused)
   default: standard
+  # forbidigo guards against reintroducing the container-hostile
+  # runtime.GOMAXPROCS call removed from run(): Go 1.25+ already sizes
+  # GOMAXPROCS from the cgroup CPU quota and updates it dynamically, and an
+  # explicit call disables that. Honor the GOMAXPROCS env var instead.
+  enable:
+    - forbidigo
   # Enable human-readable exclusion presets including std-error-handling
   # which excludes common error handling patterns like Close()
   exclusions:
@@ -19,3 +25,11 @@ linters:
       # Additional functions to exclude from checking
       exclude-functions:
         - (*github.com/ghostunnel/ghostunnel/certloader.spiffeTLSConfigSource).Close
+    forbidigo:
+      forbid:
+        - pattern: '^runtime\.GOMAXPROCS$'
+          msg: >-
+            Do not call runtime.GOMAXPROCS. Go 1.25+ defaults GOMAXPROCS to the
+            cgroup CPU quota and updates it dynamically; an explicit call
+            disables both and overrides the GOMAXPROCS env var. Honor the
+            GOMAXPROCS environment variable instead.

--- a/certloader/acmetlsconfig.go
+++ b/certloader/acmetlsconfig.go
@@ -240,13 +240,30 @@ type acmeTLSConfig struct {
 	magicConfig *certmagic.Config
 	base        *tls.Config
 	source      *acmeTLSConfigSource
+
+	// Cached config, keyed on the trust-store pointer.
+	cachedServer atomic.Pointer[cachedTLSConfig]
 }
 
 func (a *acmeTLSConfig) GetServerConfig() *tls.Config {
+	pool := a.source.getTrustStore()
+	if cached := a.cachedServer.Load(); cached != nil && cached.pool == pool {
+		return cached.config
+	}
+	config := a.buildServerConfig(pool)
+	a.cachedServer.Store(&cachedTLSConfig{pool: pool, config: config})
+	return config
+}
+
+// buildServerConfig constructs the shared server config for the given trust
+// store. The returned config is cached and shared across connections, so it
+// must never be mutated afterward. NextProtos is built on a fresh slice so
+// repeated builds never alias or grow the base config's NextProtos.
+func (a *acmeTLSConfig) buildServerConfig(pool *x509.CertPool) *tls.Config {
 	config := a.base.Clone()
 	config.GetCertificate = a.magicConfig.GetCertificate
-	config.ClientCAs = a.source.getTrustStore()
-	config.NextProtos = append(config.NextProtos, acmez.ACMETLS1Protocol)
+	config.ClientCAs = pool
+	config.NextProtos = append(append([]string(nil), a.base.NextProtos...), acmez.ACMETLS1Protocol)
 
 	// The ACME CA's TLS-ALPN-01 validator opens a probe handshake with
 	// SupportedProtos=["acme-tls/1"] (per RFC 8737) and no client certificate.

--- a/certloader/cached_config_test.go
+++ b/certloader/cached_config_test.go
@@ -1,0 +1,197 @@
+/*-
+ * Copyright 2026 Ghostunnel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certloader
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log"
+	"sync"
+	"testing"
+
+	"github.com/mholt/acmez"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCachedCertSource builds a cert-backed source over a benchCertificate,
+// whose trust store is a real atomic pointer, so a CA-bundle reload can be
+// simulated by storing a fresh pool.
+func newCachedCertSource(t *testing.T) (*benchCertificate, *certTLSConfig) {
+	t.Helper()
+	cert := newBenchCertificate()
+	source := TLSConfigSourceFromCertificate(cert, log.New(io.Discard, "", 0))
+	server, err := source.GetServerConfig(benchBaseConfig())
+	require.NoError(t, err)
+	return cert, server.(*certTLSConfig)
+}
+
+// Steady-state GetServerConfig must not allocate.
+func TestCachedCertServerConfigZeroAllocs(t *testing.T) {
+	_, cfg := newCachedCertSource(t)
+	cfg.GetServerConfig() // warm the cache
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = cfg.GetServerConfig()
+	})
+	assert.Zero(t, allocs, "steady-state GetServerConfig must not allocate")
+}
+
+// Steady-state GetClientConfig must not allocate.
+func TestCachedCertClientConfigZeroAllocs(t *testing.T) {
+	cert := newBenchCertificate()
+	source := TLSConfigSourceFromCertificate(cert, log.New(io.Discard, "", 0))
+	client, err := source.GetClientConfig(benchBaseConfig())
+	require.NoError(t, err)
+	client.GetClientConfig() // warm the cache
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = client.GetClientConfig()
+	})
+	assert.Zero(t, allocs, "steady-state GetClientConfig must not allocate")
+}
+
+// Without a reload, consecutive calls return the same shared config. This also
+// guards against a future per-connection field silently being served stale.
+func TestCachedCertServerConfigPointerIdentity(t *testing.T) {
+	_, cfg := newCachedCertSource(t)
+	first := cfg.GetServerConfig()
+	second := cfg.GetServerConfig()
+	assert.Same(t, first, second, "GetServerConfig must return the same pointer with no reload")
+}
+
+// After the trust store changes, the next call rebuilds with the new pool, and
+// subsequent calls return a stable pointer again (rebuilt once per reload).
+func TestCachedCertServerConfigReloadVisibility(t *testing.T) {
+	cert, cfg := newCachedCertSource(t)
+
+	oldPool := cert.cachedCertPool.Load()
+	first := cfg.GetServerConfig()
+	assert.Same(t, oldPool, first.ClientCAs, "config should carry the original pool")
+
+	// Simulate a CA-bundle reload: a new pool identity is published.
+	newPool := x509.NewCertPool()
+	cert.cachedCertPool.Store(newPool)
+
+	rebuilt := cfg.GetServerConfig()
+	assert.NotSame(t, first, rebuilt, "a new pool must force a rebuild")
+	assert.Same(t, newPool, rebuilt.ClientCAs, "config must carry the new pool")
+
+	again := cfg.GetServerConfig()
+	assert.Same(t, rebuilt, again, "no further reload means a stable pointer again")
+}
+
+// Same reload visibility for the client path's RootCAs.
+func TestCachedCertClientConfigReloadVisibility(t *testing.T) {
+	cert := newBenchCertificate()
+	source := TLSConfigSourceFromCertificate(cert, log.New(io.Discard, "", 0))
+	client, err := source.GetClientConfig(benchBaseConfig())
+	require.NoError(t, err)
+
+	first := client.GetClientConfig()
+	assert.Same(t, cert.cachedCertPool.Load(), first.RootCAs)
+
+	newPool := x509.NewCertPool()
+	cert.cachedCertPool.Store(newPool)
+
+	rebuilt := client.GetClientConfig()
+	assert.NotSame(t, first, rebuilt)
+	assert.Same(t, newPool, rebuilt.RootCAs, "client config must carry the reloaded pool")
+}
+
+// Hammer GetServerConfig from many goroutines while another swaps the pool.
+// Run with -race. Every returned config must carry one of the valid pools,
+// never a torn or nil value.
+func TestCachedCertServerConfigConcurrentReload(t *testing.T) {
+	cert, cfg := newCachedCertSource(t)
+
+	pools := []*x509.CertPool{cert.cachedCertPool.Load()}
+	for i := 0; i < 8; i++ {
+		pools = append(pools, x509.NewCertPool())
+	}
+	valid := make(map[*x509.CertPool]bool, len(pools))
+	for _, p := range pools {
+		valid[p] = true
+	}
+
+	stop := make(chan struct{})
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cert.cachedCertPool.Store(pools[i%len(pools)])
+				i++
+			}
+		}
+	}()
+
+	var readers sync.WaitGroup
+	for r := 0; r < 4; r++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for n := 0; n < 5000; n++ {
+				c := cfg.GetServerConfig()
+				if !valid[c.ClientCAs] {
+					t.Errorf("config carries an unexpected (torn/nil) pool: %p", c.ClientCAs)
+					return
+				}
+			}
+		}()
+	}
+
+	readers.Wait()
+	close(stop)
+	writer.Wait()
+}
+
+// Repeated calls must not grow NextProtos, and acme-tls/1 must appear exactly
+// once. Guards against appending to a shared slice on every call.
+func TestCachedACMENextProtosStable(t *testing.T) {
+	base := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+	source := &acmeTLSConfigSource{}
+	source.cachedTrustStore.Store(x509.NewCertPool())
+	cfg := &acmeTLSConfig{
+		base:   base,
+		source: source,
+	}
+
+	for i := 0; i < 10; i++ {
+		c := cfg.GetServerConfig()
+		count := 0
+		for _, p := range c.NextProtos {
+			if p == acmez.ACMETLS1Protocol {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "acme-tls/1 must appear exactly once")
+		assert.Len(t, c.NextProtos, len(base.NextProtos)+1, "NextProtos must not grow across calls")
+	}
+
+	// The base config's own NextProtos must not have been mutated/aliased.
+	assert.Len(t, base.NextProtos, 2, "build must not append to base.NextProtos")
+}

--- a/certloader/certtlsconfig.go
+++ b/certloader/certtlsconfig.go
@@ -2,8 +2,27 @@ package certloader
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"log"
+	"sync/atomic"
 )
+
+// cachedTLSConfig pairs a built *tls.Config with the trust store it was built
+// from. The pair is published together via a single atomic.Pointer so a reader
+// never sees a config matched with a stale pool.
+//
+// It lets the hot path return a shared config instead of cloning on every
+// connection. A TLS config is read-only during a handshake, so one config can
+// be shared across concurrent handshakes as long as it is never mutated after
+// publishing. The certificate is served through a callback that reads its own
+// atomic pointer, so a cert reload needs no rebuild. The trust store has no such
+// callback, so its pointer is the cache key: a reload swaps in a new pool, and
+// the next call sees the mismatch and rebuilds. Two callers racing a reload may
+// each rebuild once, which is harmless.
+type cachedTLSConfig struct {
+	pool   *x509.CertPool
+	config *tls.Config
+}
 
 // TLSConfigSourceFromCertificate creates a TLSConfigSource from a Certificate.
 func TLSConfigSourceFromCertificate(cert Certificate, logger *log.Logger) TLSConfigSource {
@@ -48,6 +67,12 @@ func (c *certTLSConfigSource) GetServerConfig(base *tls.Config) (TLSServerConfig
 type certTLSConfig struct {
 	cert Certificate
 	base *tls.Config
+
+	// Cached configs, keyed on the trust-store pointer. The certificate is
+	// served via a callback, so only the trust store can change the built
+	// config and is the only thing that invalidates the cache.
+	cachedClient atomic.Pointer[cachedTLSConfig]
+	cachedServer atomic.Pointer[cachedTLSConfig]
 }
 
 func newCertTLSConfig(cert Certificate, base *tls.Config) *certTLSConfig {
@@ -61,15 +86,25 @@ func newCertTLSConfig(cert Certificate, base *tls.Config) *certTLSConfig {
 }
 
 func (c *certTLSConfig) GetClientConfig() *tls.Config {
+	pool := c.cert.GetTrustStore()
+	if cached := c.cachedClient.Load(); cached != nil && cached.pool == pool {
+		return cached.config
+	}
 	config := c.base.Clone()
 	config.GetClientCertificate = c.cert.GetClientCertificate
-	config.RootCAs = c.cert.GetTrustStore()
+	config.RootCAs = pool
+	c.cachedClient.Store(&cachedTLSConfig{pool: pool, config: config})
 	return config
 }
 
 func (c *certTLSConfig) GetServerConfig() *tls.Config {
+	pool := c.cert.GetTrustStore()
+	if cached := c.cachedServer.Load(); cached != nil && cached.pool == pool {
+		return cached.config
+	}
 	config := c.base.Clone()
 	config.GetCertificate = c.cert.GetCertificate
-	config.ClientCAs = c.cert.GetTrustStore()
+	config.ClientCAs = pool
+	c.cachedServer.Store(&cachedTLSConfig{pool: pool, config: config})
 	return config
 }

--- a/certloader/certtlsconfig_bench_test.go
+++ b/certloader/certtlsconfig_bench_test.go
@@ -1,0 +1,119 @@
+/*-
+ * Copyright 2026 Ghostunnel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certloader
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log"
+	"testing"
+)
+
+// benchCertificate is a faithful stand-in for a real Certificate on the hot
+// path: it embeds baseCertificate, so GetCertificate/GetClientCertificate/
+// GetTrustStore are the same atomic.Pointer.Load() the production types use
+// (see baseCertificate in certificate.go) — pointer loads, zero allocation. This is
+// deliberately NOT the mockCertificateWithPrivateKey used elsewhere in tests:
+// that mock's GetTrustStore allocates a fresh x509.NewCertPool() on every call,
+// which would charge GetServerConfig/GetClientConfig an allocation that the
+// real code (a pointer load) never performs, contaminating the alloc count.
+type benchCertificate struct {
+	baseCertificate
+}
+
+func (b *benchCertificate) Reload() error { return nil }
+
+func newBenchCertificate() *benchCertificate {
+	c := &benchCertificate{}
+	// Non-nil PrivateKey so CanServe() reports true; the values are loaded via
+	// the same atomic pointers production uses, so reads are allocation-free.
+	c.cachedCertificate.Store(&tls.Certificate{PrivateKey: struct{}{}})
+	c.cachedCertPool.Store(x509.NewCertPool())
+	return c
+}
+
+// benchBaseConfig mirrors the shape of the *tls.Config Ghostunnel builds in
+// tls.go (min version, ALPN protocols, cipher suite list) so that the
+// per-connection Clone() performed by GetServerConfig/GetClientConfig copies
+// representative slice fields.
+func benchBaseConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"h2", "http/1.1"},
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		},
+	}
+}
+
+// BenchmarkGetServerConfig measures the per-accepted-connection cost of
+// certloader.Listener.Accept -> TLSServerConfig.GetServerConfig (listener.go).
+// The serial sub-benchmark reports allocs/op; the parallel one (run with
+// -cpu=1,4,8) shows how the clone cost behaves under concurrency.
+func BenchmarkGetServerConfig(b *testing.B) {
+	source := TLSConfigSourceFromCertificate(newBenchCertificate(), log.New(io.Discard, "", 0))
+	cfg, err := source.GetServerConfig(benchBaseConfig())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("serial", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = cfg.GetServerConfig()
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = cfg.GetServerConfig()
+			}
+		})
+	})
+}
+
+// BenchmarkGetClientConfig measures the per-dial cost of the matching client
+// path (dialer.go).
+func BenchmarkGetClientConfig(b *testing.B) {
+	source := TLSConfigSourceFromCertificate(newBenchCertificate(), log.New(io.Discard, "", 0))
+	cfg, err := source.GetClientConfig(benchBaseConfig())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("serial", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = cfg.GetClientConfig()
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = cfg.GetClientConfig()
+			}
+		})
+	})
+}

--- a/certloader/spiffe_tls_config.go
+++ b/certloader/spiffe_tls_config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"log"
+	"sync/atomic"
 
 	spiffeConfig "github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	spiffeApi "github.com/spiffe/go-spiffe/v2/workloadapi"
@@ -86,9 +87,24 @@ type spiffeTLSConfig struct {
 	base              *tls.Config
 	source            *spiffeApi.X509Source
 	clientDisableAuth bool
+
+	// Cached configs. SPIFFE has no reloadable trust store (the X509Source
+	// maintains itself via the Workload API and certificates are served through
+	// a callback), so the built config never changes: build once, cache forever.
+	cachedClient atomic.Pointer[tls.Config]
+	cachedServer atomic.Pointer[tls.Config]
 }
 
 func (c *spiffeTLSConfig) GetClientConfig() *tls.Config {
+	if cached := c.cachedClient.Load(); cached != nil {
+		return cached
+	}
+	config := c.buildClientConfig()
+	c.cachedClient.Store(config)
+	return config
+}
+
+func (c *spiffeTLSConfig) buildClientConfig() *tls.Config {
 	config := c.base.Clone()
 	// Go TLS stack will do hostname validation which is not a part of SPIFFE
 	// authentication. Unfortunately there is no way to just skip hostname
@@ -110,6 +126,15 @@ func (c *spiffeTLSConfig) GetClientConfig() *tls.Config {
 }
 
 func (c *spiffeTLSConfig) GetServerConfig() *tls.Config {
+	if cached := c.cachedServer.Load(); cached != nil {
+		return cached
+	}
+	config := c.buildServerConfig()
+	c.cachedServer.Store(config)
+	return config
+}
+
+func (c *spiffeTLSConfig) buildServerConfig() *tls.Config {
 	config := c.base.Clone()
 
 	if !c.clientDisableAuth {

--- a/magefile.go
+++ b/magefile.go
@@ -491,6 +491,18 @@ func (Test) All(ctx context.Context) error {
 	return nil
 }
 
+// Bench runs the Go microbenchmarks (no unit tests) with allocation stats.
+// Use it to capture before/after numbers for performance work; redirect the
+// output to a file and compare runs with benchstat. Run with higher -count and
+// -cpu via `go test` directly when you need statistically stable comparisons,
+// e.g.:
+//
+//	go test -run '^$' -bench . -benchmem -count=10 -cpu=1,4,8 ./proxy/... ./certloader/...
+func (Test) Bench(ctx context.Context) error {
+	printf("Running benchmarks...\n")
+	return sh.RunV("go", "test", "-run", "^$", "-bench", ".", "-benchmem", "-count", "6", "./...")
+}
+
 // Unit runs the unit tests.
 func (Test) Unit(ctx context.Context) error {
 	mg.Deps(cleanCoverage)

--- a/main.go
+++ b/main.go
@@ -551,8 +551,6 @@ func applyFlagImplications() {
 }
 
 func run(args []string) error {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	app.Version(fmt.Sprintf("rev %s built with %s (pkcs11: %v, keychain: %v)", version, runtime.Version(), certloader.SupportsPKCS11(), certloader.SupportsKeychain()))
 	app.Validate(validateFlags)
 	app.UsageTemplate(kingpin.LongHelpTemplate)

--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ type Environment struct {
 	shutdownTimeout time.Duration
 	dial            proxy.DialFunc
 	metrics         *sqmetrics.SquareMetrics
+	proxyMetrics    *proxy.Metrics
 	tlsConfigSource certloader.TLSConfigSource
 	regoPolicy      policy.Policy
 }
@@ -595,35 +596,64 @@ func run(args []string) error {
 	}
 
 	// Metrics
-	if *metricsGraphite != nil {
-		logger.Printf("metrics enabled; reporting metrics via TCP to %s", *metricsGraphite)
-		go graphite.Graphite(metrics.DefaultRegistry, 1*time.Second, *metricsPrefix, *metricsGraphite)
-	}
-	if *metricsURL != "" {
-		logger.Printf("metrics enabled; reporting metrics via POST to %s", *metricsURL)
+	//
+	// Metrics leave the process through exactly three sinks: the pull surface
+	// (/_metrics*, served only when --status is set) and the two push reporters
+	// (--metrics-graphite, --metrics-url). When none is configured, nothing can
+	// observe the registry, so we skip metrics collection entirely: the proxy
+	// gets no-op handles (see proxy.NilMetrics) and neither metrics background
+	// goroutine is started.
+	//
+	// NOTE: these flags are start-time-only; nothing reconfigures them at
+	// runtime (cert hot-reload does not touch them), so this predicate is
+	// decided once here and stays valid for the process lifetime. If that ever
+	// changes, this gate must be re-evaluated.
+	metricsConsumed := *statusAddress != "" || *metricsGraphite != nil || *metricsURL != ""
+
+	// proxyMetrics drives the connection hot path: live handles on the default
+	// registry when metrics are consumed, no-op handles otherwise.
+	var proxyMetrics *proxy.Metrics
+	if metricsConsumed {
+		proxyMetrics = proxy.LiveMetrics(metrics.DefaultRegistry)
+	} else {
+		proxyMetrics = proxy.NilMetrics()
 	}
 
-	// Always enable prometheus registry. The overhead should be quite minimal as an in-mem map is updated
-	// with the values.
-	pClient := prometheusmetrics.NewPrometheusProvider(metrics.DefaultRegistry, *metricsPrefix, "", prometheus.DefaultRegisterer, 1*time.Second)
-	go pClient.UpdatePrometheusMetrics()
+	// metricsSink is the sq-metrics collector; left nil when metrics are not
+	// consumed (its only readers live in serveStatus, which is not registered
+	// unless --status is set, in which case metrics are consumed).
+	var metricsSink *sqmetrics.SquareMetrics
+	if metricsConsumed {
+		if *metricsGraphite != nil {
+			logger.Printf("metrics enabled; reporting metrics via TCP to %s", *metricsGraphite)
+			go graphite.Graphite(metrics.DefaultRegistry, 1*time.Second, *metricsPrefix, *metricsGraphite)
+		}
+		if *metricsURL != "" {
+			logger.Printf("metrics enabled; reporting metrics via POST to %s", *metricsURL)
+		}
 
-	// Read CA bundle for passing to metrics library
-	ca, err := certloader.LoadTrustStore(*caBundlePath)
-	if err != nil {
-		logger.Printf("error: unable to build TLS config: %s\n", err)
-		return err
-	}
+		// Bridge go-metrics into the prometheus registry for /_metrics/prometheus.
+		// The overhead is minimal (an in-mem map is updated with the values).
+		pClient := prometheusmetrics.NewPrometheusProvider(metrics.DefaultRegistry, *metricsPrefix, "", prometheus.DefaultRegisterer, 1*time.Second)
+		go pClient.UpdatePrometheusMetrics()
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12,
-				RootCAs:    ca,
+		// Read CA bundle for passing to metrics library
+		ca, err := certloader.LoadTrustStore(*caBundlePath)
+		if err != nil {
+			logger.Printf("error: unable to build TLS config: %s\n", err)
+			return err
+		}
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					RootCAs:    ca,
+				},
 			},
-		},
+		}
+		metricsSink = sqmetrics.NewMetrics(*metricsURL, *metricsPrefix, client, *metricsInterval, metrics.DefaultRegistry, logger)
 	}
-	metrics := sqmetrics.NewMetrics(*metricsURL, *metricsPrefix, client, *metricsInterval, metrics.DefaultRegistry, logger)
 
 	switch command {
 	case serverCommand.FullCommand():
@@ -660,7 +690,8 @@ func run(args []string) error {
 			shutdownChannel: make(chan bool, 1),
 			shutdownTimeout: *processShutdownTimeout,
 			dial:            dial,
-			metrics:         metrics,
+			metrics:         metricsSink,
+			proxyMetrics:    proxyMetrics,
 			tlsConfigSource: tlsConfigSource,
 			regoPolicy:      regoPolicy,
 		}
@@ -713,7 +744,8 @@ func run(args []string) error {
 			shutdownChannel: make(chan bool, 1),
 			shutdownTimeout: *processShutdownTimeout,
 			dial:            dial,
-			metrics:         metrics,
+			metrics:         metricsSink,
+			proxyMetrics:    proxyMetrics,
 			tlsConfigSource: tlsConfigSource,
 			regoPolicy:      policy,
 		}
@@ -803,6 +835,7 @@ func serverListen(env *Environment, regoPolicy policy.Policy) error {
 		logger,
 		proxyLoggerFlags(*quiet),
 		serverProxyProtoMode(),
+		env.proxyMetrics,
 	)
 
 	if *statusAddress != "" {
@@ -844,6 +877,7 @@ func clientListen(env *Environment) error {
 		logger,
 		proxyLoggerFlags(*quiet),
 		proxy.ProxyProtocolOff,
+		env.proxyMetrics,
 	)
 
 	if *statusAddress != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -579,7 +579,6 @@ func TestValidateStatusAddress(t *testing.T) {
 	}
 }
 
-
 func TestInvalidCABundle(t *testing.T) {
 	cmd := []string{
 		"server",

--- a/proxy/benchmark_test.go
+++ b/proxy/benchmark_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -53,5 +55,55 @@ func benchmarkCopyData(b *testing.B, proxy *Proxy, size int) {
 		}()
 
 		proxy.copyData(dstIn, srcOut)
+	}
+}
+
+// benchTCPConn is a net.Conn stub whose addresses are *net.TCPAddr, so
+// proxyProtoHeader exercises the real TCPv4 transportProtocol branch rather
+// than falling through to UNSPEC.
+type benchTCPConn struct {
+	net.Conn
+}
+
+func (benchTCPConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 51000}
+}
+
+func (benchTCPConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(10, 0, 0, 2), Port: 443}
+}
+
+// BenchmarkProxyProtoHeader measures construction of the PROXY protocol v2
+// header on the accept hot path (proxyProtoHeader in proxy.go). It runs
+// once per connection when a PROXY-protocol mode is enabled, and reports the
+// allocations that construction performs. TLSFull additionally copies the peer
+// cert DER, so it is benchmarked separately from TLS mode.
+func BenchmarkProxyProtoHeader(b *testing.B) {
+	_, leaf := benchSelfSignedCert(b)
+	conn := benchTCPConn{}
+	logger := &testLogger{}
+
+	state := &tls.ConnectionState{
+		Version:            tls.VersionTLS13,
+		CipherSuite:        tls.TLS_AES_128_GCM_SHA256,
+		NegotiatedProtocol: "h2",
+		ServerName:         "example.com",
+		PeerCertificates:   []*x509.Certificate{leaf},
+	}
+
+	for _, tc := range []struct {
+		name string
+		mode ProxyProtocolMode
+	}{
+		{"conn", ProxyProtocolConn},
+		{"tls", ProxyProtocolTLS},
+		{"tls-full", ProxyProtocolTLSFull},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = proxyProtoHeader(conn, state, tc.mode, logger)
+			}
+		})
 	}
 }

--- a/proxy/churn_bench_test.go
+++ b/proxy/churn_bench_test.go
@@ -29,6 +29,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	metrics "github.com/rcrowley/go-metrics"
 )
 
 // benchSelfSignedCert generates a self-signed ECDSA P-256 certificate usable as
@@ -85,7 +87,70 @@ func benchSelfSignedCert(tb testing.TB) (tls.Certificate, *x509.Certificate) {
 // incoming listener uses plain tls.NewListener; the certloader per-connection
 // tls.Config clone is measured separately by BenchmarkGetServerConfig in the
 // certloader package.
+//
+// This variant uses live metrics (nil handles fall back to the default registry
+// in proxy.New), i.e. the path taken when a metrics sink is configured. It is
+// the figure for the metrics-enabled (sink-configured) accept path.
 func BenchmarkConnectionChurn(b *testing.B) {
+	benchmarkConnectionChurn(b, nil)
+}
+
+// BenchmarkConnectionChurnNoSink runs the identical churn workload but with
+// no-op metric handles (proxy.NilMetrics) — the path Ghostunnel takes when
+// started with no metrics sink (--status, --metrics-graphite and --metrics-url
+// all unset, the default). Comparing it against BenchmarkConnectionChurn
+// isolates the per-connection metric-bookkeeping cost removed by skipping metric
+// collection in the default configuration.
+//
+// Note: each iteration performs a full ECDSA handshake, which dominates
+// per-connection CPU, so the metric delta is small relative to total time and
+// is clearest under contention (-cpu=4,8), where the two shared go-metrics
+// timers' mutex is hottest. A mutex/block profile remains the most direct way
+// to see the timer contention.
+func BenchmarkConnectionChurnNoSink(b *testing.B) {
+	benchmarkConnectionChurn(b, NilMetrics())
+}
+
+// BenchmarkConnMetricsBookkeeping isolates the per-connection metric updates the
+// accept path performs (the two timers plus the open/total/success counters),
+// with no handshake or network in the loop. This is the measurement that
+// isolates that cost directly: the metrics=live column records to real
+// go-metrics handles, metrics=nosink uses proxy.NilMetrics, and the gap is the
+// CPU — and, under -cpu=4,8, the lock contention — removed when no metrics sink
+// is configured. The end-to-end BenchmarkConnectionChurn cannot show this
+// because the ~1ms ECDSA handshake dwarfs this sub-microsecond bookkeeping.
+//
+// Compare the two columns directly with:
+//
+//	go test -run '^$' -bench BenchmarkConnMetricsBookkeeping -count=10 -cpu=1,4,8 ./proxy/ > m.txt
+//	benchstat -col /metrics m.txt
+func BenchmarkConnMetricsBookkeeping(b *testing.B) {
+	// A fresh registry for the live case so it never touches the package
+	// default registry (and so repeated runs don't accumulate state).
+	run := func(b *testing.B, m *Metrics) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			start := time.Now()
+			for pb.Next() {
+				// Mirrors the per-connection sequence in Accept/forceHandshake.
+				m.OpenCounter.Inc(1)
+				m.TotalCounter.Inc(1)
+				m.HandshakeTimer.UpdateSince(start)
+				m.SuccessCounter.Inc(1)
+				m.OpenCounter.Dec(1)
+				m.ConnTimer.UpdateSince(start)
+			}
+		})
+	}
+	b.Run("metrics=live", func(b *testing.B) { run(b, LiveMetrics(metrics.NewRegistry())) })
+	b.Run("metrics=nosink", func(b *testing.B) { run(b, NilMetrics()) })
+}
+
+// benchmarkConnectionChurn is the shared body for the live and no-sink churn
+// benchmarks; connMetrics selects which metric handles the proxy records to
+// (nil → default registry, NilMetrics → no-op).
+func benchmarkConnectionChurn(b *testing.B, connMetrics *Metrics) {
 	serverCert, leaf := benchSelfSignedCert(b)
 
 	pool := x509.NewCertPool()
@@ -148,7 +213,7 @@ func BenchmarkConnectionChurn(b *testing.B) {
 
 	// Unlimited semaphore (0) so concurrency isn't capped — proxyForTest pins
 	// it at 1, which would serialize the churn we want to measure. No logging.
-	p := New(incoming, 5*time.Second, 5*time.Second, 0, 0, dialer, &testLogger{}, 0, ProxyProtocolOff)
+	p := New(incoming, 5*time.Second, 5*time.Second, 0, 0, dialer, &testLogger{}, 0, ProxyProtocolOff, connMetrics)
 	go p.Accept()
 	defer func() {
 		p.Shutdown()

--- a/proxy/churn_bench_test.go
+++ b/proxy/churn_bench_test.go
@@ -1,0 +1,194 @@
+/*-
+ * Copyright 2026 Ghostunnel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+// benchSelfSignedCert generates a self-signed ECDSA P-256 certificate usable as
+// both a server and client certificate, and as its own CA. It mirrors the
+// selfSignedCert helper in proxy_test.go but accepts testing.TB so it can be
+// used from benchmarks. It returns the tls.Certificate and the parsed leaf.
+func benchSelfSignedCert(tb testing.TB) (tls.Certificate, *x509.Certificate) {
+	tb.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:         "test-cn",
+			OrganizationalUnit: []string{"test-ou"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	leaf, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: key, Leaf: leaf}, leaf
+}
+
+// BenchmarkConnectionChurn drives the full connection-acceptance hot path under
+// load: a real TCP listener wrapped in TLS, a real echo backend, and the proxy
+// accept loop. Each iteration opens a fresh mutually-authenticated TLS
+// connection (no client session cache, so every connection is a full
+// handshake), sends one byte, reads the echo, and closes. Run with
+// -cpu=1,4,8 to observe how the per-connection accept path scales across cores.
+//
+// Unlike BenchmarkCopyData (which uses net.Pipe and measures only the
+// steady-state copy loop), this benchmark exercises real sockets and a
+// *tls.Conn, so it observes the real per-connection accept path (handshake,
+// metric bookkeeping, deadlines at close, the single accept goroutine). The
+// incoming listener uses plain tls.NewListener; the certloader per-connection
+// tls.Config clone is measured separately by BenchmarkGetServerConfig in the
+// certloader package.
+func BenchmarkConnectionChurn(b *testing.B) {
+	serverCert, leaf := benchSelfSignedCert(b)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	serverConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    pool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	clientConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS12,
+		// No ClientSessionCache: every dial performs a full handshake, which
+		// is the connection-churn case this benchmark is meant to stress.
+	}
+
+	// Echo backend: accept each connection, read one request, echo it, then
+	// close. The backend is deliberately the *active closer*: that makes the
+	// load generator's client sockets passive closers, so their ephemeral
+	// ports are released immediately instead of lingering in TIME_WAIT. Without
+	// this, high parallel churn on localhost exhausts the ephemeral port range
+	// ("can't assign requested address") long before the proxy is the
+	// bottleneck.
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer backend.Close()
+	go func() {
+		for {
+			conn, err := backend.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				buf := make([]byte, 64)
+				if n, err := c.Read(buf); err == nil && n > 0 {
+					_, _ = c.Write(buf[:n])
+				}
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+
+	// Incoming side: plain TLS listener wrapping a real TCP socket.
+	rawIncoming, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	incoming := tls.NewListener(rawIncoming, serverConfig)
+
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", backend.Addr().String())
+	}
+
+	// Unlimited semaphore (0) so concurrency isn't capped — proxyForTest pins
+	// it at 1, which would serialize the churn we want to measure. No logging.
+	p := New(incoming, 5*time.Second, 5*time.Second, 0, 0, dialer, &testLogger{}, 0, ProxyProtocolOff)
+	go p.Accept()
+	defer func() {
+		p.Shutdown()
+		p.Wait()
+	}()
+
+	incomingAddr := incoming.Addr().String()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		buf := make([]byte, 64)
+		for pb.Next() {
+			conn, err := tls.Dial("tcp", incomingAddr, clientConfig)
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			if _, err := conn.Write([]byte("A")); err != nil {
+				b.Error(err)
+				_ = conn.Close()
+				return
+			}
+			// Drain to EOF: receive the echo and then the backend-initiated
+			// close, so this client is the passive closer (see backend above).
+			got := 0
+			for {
+				n, err := conn.Read(buf)
+				got += n
+				if err != nil {
+					if err != io.EOF {
+						b.Error(err)
+					}
+					break
+				}
+			}
+			if got == 0 {
+				b.Error("no echo received from backend")
+			}
+			_ = conn.Close()
+		}
+	})
+}

--- a/proxy/metrics_test.go
+++ b/proxy/metrics_test.go
@@ -1,0 +1,138 @@
+/*-
+ * Copyright 2015 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	metrics "github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNilMetricsAreNoOps verifies that the no-op metrics handles record
+// nothing. This is what makes skipping collection (when no sink is configured)
+// free on the connection hot path: updates land on Nil* handles. Critically,
+// a no-op Timer must still not swallow work — but since we never route the
+// connection handler through Timer.Time (we use UpdateSince), all that matters
+// here is that updates are observably no-ops.
+func TestNilMetricsAreNoOps(t *testing.T) {
+	m := NilMetrics()
+
+	counters := []metrics.Counter{
+		m.OpenCounter, m.ConnTimeoutCounter, m.TotalCounter, m.SuccessCounter,
+		m.ErrorCounter, m.HandshakeTimeoutCounter,
+	}
+	for _, c := range counters {
+		assert.IsType(t, metrics.NilCounter{}, c, "expected a no-op counter")
+		c.Inc(1)
+		assert.Equal(t, int64(0), c.Count(), "no-op counter must not record")
+	}
+
+	timers := []metrics.Timer{m.HandshakeTimer, m.ConnTimer}
+	for _, tm := range timers {
+		assert.IsType(t, metrics.NilTimer{}, tm, "expected a no-op timer")
+		tm.UpdateSince(time.Now())
+		assert.Equal(t, int64(0), tm.Count(), "no-op timer must not record")
+	}
+}
+
+// TestLiveMetricsRegisterCanonicalNames verifies that LiveMetrics registers
+// every metric under its canonical, externally-visible name on the supplied
+// registry, and that the returned handles are the registered ones. The names
+// are part of Ghostunnel's exported surface, so this guards against an
+// accidental rename.
+func TestLiveMetricsRegisterCanonicalNames(t *testing.T) {
+	registry := metrics.NewRegistry()
+	m := LiveMetrics(registry)
+
+	expected := map[string]any{
+		"conn.open":      m.OpenCounter,
+		"conn.timeout":   m.ConnTimeoutCounter,
+		"accept.total":   m.TotalCounter,
+		"accept.success": m.SuccessCounter,
+		"accept.error":   m.ErrorCounter,
+		"accept.timeout": m.HandshakeTimeoutCounter,
+		"conn.handshake": m.HandshakeTimer,
+		"conn.lifetime":  m.ConnTimer,
+	}
+	for name, handle := range expected {
+		got := registry.Get(name)
+		assert.NotNil(t, got, "metric %q must be registered", name)
+		assert.Equal(t, handle, got, "metric %q handle must match the registered one", name)
+	}
+
+	// Live handles actually record.
+	m.TotalCounter.Inc(1)
+	assert.Equal(t, int64(1), m.TotalCounter.Count(), "live counter must record")
+}
+
+// TestNewMetricsWiring pins the injection seam New relies on: passing nil keeps
+// the historical default-registry behavior, while NilMetrics yields a proxy
+// whose hot-path handles never touch a registry. This is the proxy-side guard
+// against silently re-enabling collection.
+func TestNewMetricsWiring(t *testing.T) {
+	p := proxyForTest(&failingListener{}, nil)
+	assert.Same(t, defaultMetrics, p.metrics, "nil handle must fall back to the default registry")
+
+	nilP := New(&failingListener{}, time.Second, time.Second, time.Second, 1, nil, &testLogger{}, 0, ProxyProtocolOff, NilMetrics())
+	assert.IsType(t, metrics.NilCounter{}, nilP.metrics.ErrorCounter, "NilMetrics must produce no-op handles")
+	assert.IsType(t, metrics.NilTimer{}, nilP.metrics.ConnTimer, "NilMetrics must produce no-op handles")
+}
+
+// TestNilMetricsProxyForwardsData is the regression guard for the hot-path
+// restructure: the connection handler used to be wrapped in connTimer.Time(fn),
+// but a no-op Timer's Time() never runs fn — so with NilMetrics that would have
+// silently dropped every connection. This proves a NilMetrics proxy still
+// forwards bytes end-to-end.
+func TestNilMetricsProxyForwardsData(t *testing.T) {
+	// Plain TCP listener (incoming) and backend (target).
+	incoming, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	target, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	defer target.Close()
+
+	dialer := func(ctx context.Context) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", target.Addr().String())
+	}
+
+	p := New(incoming, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolOff, NilMetrics())
+	go p.Accept()
+	defer p.Shutdown()
+
+	src, err := net.Dial("tcp", incoming.Addr().String())
+	assert.Nil(t, err)
+	defer src.Close()
+
+	dst, err := target.Accept()
+	assert.Nil(t, err)
+	defer dst.Close()
+
+	_, err = src.Write([]byte("ping"))
+	assert.Nil(t, err)
+
+	_ = dst.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 4)
+	n, err := io.ReadFull(dst, buf)
+	assert.Nil(t, err, "backend must receive forwarded data even with no-op metrics")
+	assert.Equal(t, "ping", string(buf[:n]))
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -56,7 +56,71 @@ var (
 	handshakeTimeoutCounter = metrics.GetOrRegisterCounter("accept.timeout", metrics.DefaultRegistry)
 	handshakeTimer          = metrics.GetOrRegisterTimer("conn.handshake", metrics.DefaultRegistry)
 	connTimer               = metrics.GetOrRegisterTimer("conn.lifetime", metrics.DefaultRegistry)
+
+	// defaultMetrics wraps the package-level handles registered above on the
+	// default registry. New uses it when a caller passes nil, preserving the
+	// historical behavior of reporting to metrics.DefaultRegistry.
+	defaultMetrics = &Metrics{
+		OpenCounter:             openCounter,
+		ConnTimeoutCounter:      connTimeoutCounter,
+		TotalCounter:            totalCounter,
+		SuccessCounter:          successCounter,
+		ErrorCounter:            errorCounter,
+		HandshakeTimeoutCounter: handshakeTimeoutCounter,
+		HandshakeTimer:          handshakeTimer,
+		ConnTimer:               connTimer,
+	}
 )
+
+// Metrics holds the go-metrics handles updated on the connection hot path.
+// Injecting the handles (instead of reading package globals) lets the caller
+// decide, once at startup, whether to collect at all: pass LiveMetrics to
+// record against a registry, or NilMetrics to make every update a no-op when no
+// metrics sink is configured. The metric names are part of Ghostunnel's
+// exported surface and must not change.
+type Metrics struct {
+	OpenCounter             metrics.Counter // conn.open
+	ConnTimeoutCounter      metrics.Counter // conn.timeout
+	TotalCounter            metrics.Counter // accept.total
+	SuccessCounter          metrics.Counter // accept.success
+	ErrorCounter            metrics.Counter // accept.error
+	HandshakeTimeoutCounter metrics.Counter // accept.timeout
+	HandshakeTimer          metrics.Timer   // conn.handshake
+	ConnTimer               metrics.Timer   // conn.lifetime
+}
+
+// LiveMetrics registers the connection metrics under their canonical names on
+// the given registry and returns handles that record to it. Registration is
+// idempotent (GetOrRegister), so repeated calls with the same registry return
+// the same underlying handles.
+func LiveMetrics(registry metrics.Registry) *Metrics {
+	return &Metrics{
+		OpenCounter:             metrics.GetOrRegisterCounter("conn.open", registry),
+		ConnTimeoutCounter:      metrics.GetOrRegisterCounter("conn.timeout", registry),
+		TotalCounter:            metrics.GetOrRegisterCounter("accept.total", registry),
+		SuccessCounter:          metrics.GetOrRegisterCounter("accept.success", registry),
+		ErrorCounter:            metrics.GetOrRegisterCounter("accept.error", registry),
+		HandshakeTimeoutCounter: metrics.GetOrRegisterCounter("accept.timeout", registry),
+		HandshakeTimer:          metrics.GetOrRegisterTimer("conn.handshake", registry),
+		ConnTimer:               metrics.GetOrRegisterTimer("conn.lifetime", registry),
+	}
+}
+
+// NilMetrics returns metrics handles whose updates are all no-ops. Use it when
+// no metrics sink is configured so the connection hot path spends nothing
+// updating contended timers; nothing observes the registry in that case anyway.
+func NilMetrics() *Metrics {
+	return &Metrics{
+		OpenCounter:             metrics.NilCounter{},
+		ConnTimeoutCounter:      metrics.NilCounter{},
+		TotalCounter:            metrics.NilCounter{},
+		SuccessCounter:          metrics.NilCounter{},
+		ErrorCounter:            metrics.NilCounter{},
+		HandshakeTimeoutCounter: metrics.NilCounter{},
+		HandshakeTimer:          metrics.NilTimer{},
+		ConnTimer:               metrics.NilTimer{},
+	}
+}
 
 const (
 	// LogConnections will log messages about open/closed connections.
@@ -105,6 +169,9 @@ type Proxy struct {
 	cancel  context.CancelFunc
 	// Pool for buffers
 	pool sync.Pool
+	// Metrics handles for the connection hot path. Either live (recording to a
+	// registry) or no-op (NilMetrics) when no metrics sink is configured.
+	metrics *Metrics
 }
 
 // PROXY protocol v2 client flag constants (from spec section 2.2.5).
@@ -246,7 +313,14 @@ func New(
 	dial DialFunc,
 	logger Logger,
 	loggerFlags int,
-	proxyProtocol ProxyProtocolMode) *Proxy {
+	proxyProtocol ProxyProtocolMode,
+	connMetrics *Metrics) *Proxy {
+
+	// A nil handle means "use the default registry" (the historical behavior);
+	// callers that want to skip collection pass NilMetrics explicitly.
+	if connMetrics == nil {
+		connMetrics = defaultMetrics
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -262,6 +336,7 @@ func New(
 		handlers:        &sync.WaitGroup{},
 		context:         ctx,
 		cancel:          cancel,
+		metrics:         connMetrics,
 		pool: sync.Pool{
 			New: func() any {
 				b := make([]byte, 1<<15 /* 32 KiB */)
@@ -335,7 +410,7 @@ func (p *Proxy) Accept() {
 				return
 			}
 
-			errorCounter.Inc(1)
+			p.metrics.ErrorCounter.Inc(1)
 			p.connSemaphore.Release(1)
 			p.logConditional(LogConnectionErrors, "error accepting connection: %s", err)
 
@@ -357,13 +432,21 @@ func (p *Proxy) Accept() {
 		acceptBackoff = 0
 
 		p.handlers.Add(1)
-		go connTimer.Time(func() {
-			openCounter.Inc(1)
-			totalCounter.Inc(1)
+		go func() {
+			// Record the connection lifetime explicitly rather than via
+			// Timer.Time: a no-op timer's Time() would not run the closure at
+			// all, which would skip connection handling when metrics are off.
+			// UpdateSince is deferred first so it fires last (after the close
+			// defer below), matching Timer.Time's "measure the whole handler".
+			startTime := time.Now()
+			defer p.metrics.ConnTimer.UpdateSince(startTime)
+
+			p.metrics.OpenCounter.Inc(1)
+			p.metrics.TotalCounter.Inc(1)
 
 			defer func() {
 				conn.Close()
-				openCounter.Dec(1)
+				p.metrics.OpenCounter.Dec(1)
 				p.handlers.Done()
 				p.connSemaphore.Release(1)
 			}()
@@ -371,9 +454,9 @@ func (p *Proxy) Accept() {
 			ctx, cancel := context.WithTimeout(p.context, p.ConnectTimeout)
 			defer cancel()
 
-			err := forceHandshake(ctx, conn)
+			err := forceHandshake(ctx, conn, p.metrics)
 			if err != nil {
-				errorCounter.Inc(1)
+				p.metrics.ErrorCounter.Inc(1)
 				p.logConditional(LogHandshakeErrors, "error on TLS handshake from %s: %s", conn.RemoteAddr(), err)
 				return
 			}
@@ -409,9 +492,9 @@ func (p *Proxy) Accept() {
 				}
 			}
 
-			successCounter.Inc(1)
+			p.metrics.SuccessCounter.Inc(1)
 			p.fuse(conn, backend)
-		})
+		}()
 	}
 }
 
@@ -433,15 +516,15 @@ func isACMEChallengeConn(conn net.Conn) bool {
 // unauthenticated clients would be able to open connections and leave them
 // hanging forever. Going through the handshake verifies that clients have a
 // valid client cert and are allowed to talk to us.
-func forceHandshake(ctx context.Context, conn net.Conn) error {
+func forceHandshake(ctx context.Context, conn net.Conn, m *Metrics) error {
 	if tlsConn, ok := conn.(*tls.Conn); ok {
 		startTime := time.Now()
-		defer handshakeTimer.UpdateSince(startTime)
+		defer m.HandshakeTimer.UpdateSince(startTime)
 
 		err := tlsConn.HandshakeContext(ctx)
 		if isTimeoutError(err) {
 			// If we timed out, increment timeout metric
-			handshakeTimeoutCounter.Inc(1)
+			m.HandshakeTimeoutCounter.Inc(1)
 		}
 		if err != nil {
 			return err
@@ -539,7 +622,7 @@ func (p *Proxy) copyData(dst net.Conn, src net.Conn) (written int64) {
 		// We don't log individual "read from closed connection" errors, because
 		// we already have a log statement showing that a pipe has been closed.
 		if isTimeoutError(err) {
-			connTimeoutCounter.Inc(1)
+			p.metrics.ConnTimeoutCounter.Inc(1)
 		}
 		p.logConditional(LogConnectionErrors, "error during copy: %s", err)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -57,11 +57,11 @@ func (m *failingListener) Close() error              { return nil }
 func (m *failingListener) Addr() net.Addr            { return nil }
 
 func proxyForTest(listener net.Listener, dialer DialFunc) *Proxy {
-	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolOff)
+	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolOff, nil)
 }
 
 func proxyForTestWithProxyProtocol(listener net.Listener, dialer DialFunc) *Proxy {
-	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolConn)
+	return New(listener, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolConn, nil)
 }
 
 func TestAbortedConnection(t *testing.T) {
@@ -191,7 +191,7 @@ func TestAcceptErrorLogged(t *testing.T) {
 	}}
 
 	ln := newCountingFailingListener()
-	p := New(ln, 5*time.Second, 5*time.Second, 5*time.Second, 1, nil, logger, LogConnectionErrors, ProxyProtocolOff)
+	p := New(ln, 5*time.Second, 5*time.Second, 5*time.Second, 1, nil, logger, LogConnectionErrors, ProxyProtocolOff, nil)
 
 	go p.Accept()
 	defer func() {
@@ -234,7 +234,7 @@ func TestAcceptErrorNotLoggedWhenFlagDisabled(t *testing.T) {
 
 	ln := newCountingFailingListener()
 	// loggerFlags = 0 (no flags set) -- accept errors must not be logged.
-	p := New(ln, 5*time.Second, 5*time.Second, 5*time.Second, 1, nil, logger, 0, ProxyProtocolOff)
+	p := New(ln, 5*time.Second, 5*time.Second, 5*time.Second, 1, nil, logger, 0, ProxyProtocolOff, nil)
 
 	go p.Accept()
 	defer func() {
@@ -889,7 +889,7 @@ func TestCopyDataErrorClassification(t *testing.T) {
 		lg := &callbackLogger{callback: func(format string, v ...any) {
 			logs = append(logs, logEntry{format: format, args: v})
 		}}
-		p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, lg, flags, ProxyProtocolOff)
+		p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, lg, flags, ProxyProtocolOff, nil)
 		return p, &logs
 	}
 
@@ -983,7 +983,7 @@ func TestForceHandshakeNonTLSConn(t *testing.T) {
 
 	// forceHandshake should be a no-op for non-TLS connections
 	ctx := context.Background()
-	err = forceHandshake(ctx, conn)
+	err = forceHandshake(ctx, conn, defaultMetrics)
 	assert.Nil(t, err, "forceHandshake should succeed for non-TLS conn")
 }
 
@@ -1110,7 +1110,7 @@ func TestACMEChallengeNotForwardedToBackend(t *testing.T) {
 
 func TestLogConnectionMessageDisabled(t *testing.T) {
 	// Test with LogConnections disabled
-	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, &testLogger{}, 0, ProxyProtocolOff)
+	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, &testLogger{}, 0, ProxyProtocolOff, nil)
 
 	// Create pipe connections
 	src, dst := net.Pipe()
@@ -1128,7 +1128,7 @@ func TestLogConditional(t *testing.T) {
 	}}
 
 	// Test with flag enabled
-	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, logger, LogConnectionErrors, ProxyProtocolOff)
+	p := New(nil, 5*time.Second, 5*time.Second, 0, 0, nil, logger, LogConnectionErrors, ProxyProtocolOff, nil)
 	p.logConditional(LogConnectionErrors, "test message")
 	assert.True(t, logged, "should log when flag is enabled")
 
@@ -1638,7 +1638,7 @@ func TestProxyProtocolTLSModeSuccess(t *testing.T) {
 		return d.DialContext(ctx, "tcp", target.Addr().String())
 	}
 
-	p := New(incoming, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolTLS)
+	p := New(incoming, 5*time.Second, 5*time.Second, 5*time.Second, 1, dialer, &testLogger{}, LogEverything, ProxyProtocolTLS, nil)
 	go p.Accept()
 	defer p.Shutdown()
 

--- a/unix_test.go
+++ b/unix_test.go
@@ -129,6 +129,7 @@ func TestSignalHandlerReloadAndShutdown(t *testing.T) {
 		logger,
 		proxy.LogEverything,
 		proxy.ProxyProtocolOff,
+		nil,
 	)
 
 	done := make(chan struct{})


### PR DESCRIPTION
Small perf improvements in hot path:
- Skip metrics collection if no metrics sink/status port configured
- Better config caching, avoid re-cloning on every connection
- Don't call GOMAXPROCS anymore (newer Go handles this better, deals with containers natively)
- Add benchmarks so we can quantify improvements 