### PR TITLE
Website styling fixes

### DIFF
--- a/website/layouts/_default/_markup/render-codeblock-bash.html
+++ b/website/layouts/_default/_markup/render-codeblock-bash.html
@@ -1,4 +1,4 @@
-{{- $title := or (.Attributes.title) "shell" -}}
+{{- $title := or (.Attributes.title) "Terminal" -}}
 {{- $body := trim .Inner "\n\r" | htmlEscape -}}
 {{- $body = replaceRE `(?m)^\$` `<span class="t-prompt">$0</span>` $body -}}
 {{- $body = replaceRE `(?m)^#.*$` `<span class="t-comment">$0</span>` $body -}}

--- a/website/layouts/_default/_markup/render-codeblock-sh.html
+++ b/website/layouts/_default/_markup/render-codeblock-sh.html
@@ -1,4 +1,4 @@
-{{- $title := or (.Attributes.title) "shell" -}}
+{{- $title := or (.Attributes.title) "Terminal" -}}
 {{- $body := trim .Inner "\n\r" | htmlEscape -}}
 {{- $body = replaceRE `(?m)^\$` `<span class="t-prompt">$0</span>` $body -}}
 {{- $body = replaceRE `(?m)^#.*$` `<span class="t-comment">$0</span>` $body -}}

--- a/website/layouts/_default/single.html
+++ b/website/layouts/_default/single.html
@@ -3,13 +3,13 @@
 <div class="with-sidebar">
   {{ partial "sidebar.html" . }}
   <article class="content" data-pagefind-body>
-    <h1>{{ .Title }}</h1>
+    <div class="page-header">
+      <h1>{{ .Title }}</h1>
+      {{ with .File }}
+      <a class="edit-page" href="https://github.com/ghostunnel/ghostunnel/edit/master/{{ .Path }}" target="_blank" rel="noopener">{{ partial "icon-github.html" }} Edit on GitHub</a>
+      {{ end }}
+    </div>
     {{ .Content }}
-    {{ with .File }}
-    <footer class="edit-page">
-      <a href="https://github.com/ghostunnel/ghostunnel/edit/master/{{ .Path }}" target="_blank" rel="noopener">{{ partial "icon-github.html" }} Edit this page on GitHub</a>
-    </footer>
-    {{ end }}
     {{ partial "prev-next.html" . }}
   </article>
 </div>

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -1655,20 +1655,34 @@ a:hover {
   }
 }
 
+/* === Page header (title + edit link) === */
+.page-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.page-header h1 {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
 /* === Edit on GitHub link === */
 .edit-page {
-  margin-top: 3rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border);
+  flex: none;
   font-size: 0.85rem;
-}
-
-.edit-page a {
   color: var(--text-muted);
   text-decoration: none;
+  white-space: nowrap;
 }
 
-.edit-page a:hover {
+.edit-page:hover {
   color: var(--accent);
 }
 

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -1385,6 +1385,14 @@ a:hover {
   color: var(--text-heading);
 }
 
+/* Dark code frames need light selected text + a stronger highlight, since
+   the global ::selection color above is tuned for the light page. */
+.terminal ::selection,
+.terminal-body ::selection {
+  background: rgba(60, 190, 210, 0.35);
+  color: var(--ink-text-bright);
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -1479,52 +1487,7 @@ a:hover {
   outline-offset: 1px;
 }
 
-/* In-bar buttons (terminal / editor frames) */
-.copy-btn--bar {
-  margin-left: auto;
-  align-self: center;
-}
-
-/* Dark terminal bars: subtle faint ink, brightens on hover */
-.terminal .copy-btn--bar {
-  color: var(--ink-text-faint);
-}
-
-.terminal .copy-btn--bar:hover,
-.terminal .copy-btn--bar:focus-visible {
-  color: var(--ink-text-bright);
-  background: rgba(255, 255, 255, 0.08);
-}
-
-.terminal .copy-btn--bar.copied,
-.terminal .copy-btn--bar.copied:hover {
-  color: var(--accent-bright);
-}
-
-/* Windows terminal bar: controls already sit at the right edge */
-.terminal--windows .copy-btn--bar {
-  margin-left: 0;
-  margin-right: 0.6rem;
-}
-
-/* Light editor bars */
-.editor .copy-btn--bar {
-  margin-right: 0.5rem;
-  color: var(--text-muted);
-}
-
-.editor .copy-btn--bar:hover,
-.editor .copy-btn--bar:focus-visible {
-  color: var(--accent);
-  background: var(--accent-faint);
-}
-
-.editor .copy-btn--bar.copied,
-.editor .copy-btn--bar.copied:hover {
-  color: var(--accent);
-}
-
-/* Floating buttons on plain <pre><code> blocks */
+/* Floating buttons — plain <pre><code> blocks and terminal/editor frames */
 .copy-wrap {
   position: relative;
 }
@@ -1559,6 +1522,29 @@ a:hover {
 .copy-btn--floating.copied,
 .copy-btn--floating.copied:hover {
   color: var(--accent);
+}
+
+/* Terminal frames: solid dark chip over the dark body so the icon reads
+   clearly against the code behind it. */
+.copy-btn--terminal {
+  background: rgba(8, 26, 33, 0.82);
+  border-color: rgba(120, 200, 215, 0.28);
+  color: var(--ink-text);
+  box-shadow: none;
+  /* Override the dimmed floating default — the chip carries its own contrast. */
+  opacity: 0.9;
+}
+
+.copy-btn--terminal:hover,
+.copy-btn--terminal:focus-visible {
+  color: var(--ink-text-bright);
+  border-color: rgba(120, 200, 215, 0.5);
+  background: rgba(12, 38, 47, 0.95);
+}
+
+.copy-btn--terminal.copied,
+.copy-btn--terminal.copied:hover {
+  color: var(--accent-bright);
 }
 
 /* === Prev/next page navigation === */

--- a/website/static/js/copy-code.js
+++ b/website/static/js/copy-code.js
@@ -47,14 +47,28 @@
     return btn;
   }
 
+  // Wrap a <pre> in a relatively-positioned container so a floating button
+  // can be pinned to its top-right corner without scrolling with the content.
+  function wrapAndAdd(pre, code, extraClass) {
+    var wrap = document.createElement("div");
+    wrap.className = "copy-wrap";
+    pre.parentNode.insertBefore(wrap, pre);
+    wrap.appendChild(pre);
+    wrap.appendChild(makeButton(code, "copy-btn--floating " + extraClass));
+  }
+
   function init() {
-    // Terminal and editor frames: put the button in the title bar.
+    // Terminal and editor frames: float the button in the top-right of the
+    // code body, just below the title bar, so it clears the frame chrome.
     var frames = document.querySelectorAll(".terminal, .editor");
     frames.forEach(function (frame) {
-      var bar = frame.querySelector(".terminal-bar, .editor-bar");
-      var code = frame.querySelector("pre code");
-      if (!bar || !code) return;
-      bar.appendChild(makeButton(code, "copy-btn--bar"));
+      var pre = frame.querySelector("pre.terminal-body, pre.editor-body");
+      var code = pre && pre.querySelector("code");
+      if (!pre || !code) return;
+      var variant = frame.classList.contains("editor")
+        ? "copy-btn--editor"
+        : "copy-btn--terminal";
+      wrapAndAdd(pre, code, variant);
     });
 
     // Any other <pre><code> blocks: wrap the <pre> so the button can be
@@ -63,11 +77,7 @@
     codes.forEach(function (code) {
       var pre = code.parentNode;
       if (pre.closest(".terminal, .editor, .copy-wrap")) return;
-      var wrap = document.createElement("div");
-      wrap.className = "copy-wrap";
-      pre.parentNode.insertBefore(wrap, pre);
-      wrap.appendChild(pre);
-      wrap.appendChild(makeButton(code, "copy-btn--floating"));
+      wrapAndAdd(pre, code, "");
     });
   }
 


### PR DESCRIPTION
Move the 'edit on github' link to the top right of docs pages so it doesn't clash with the prev/next buttons. Fix some of the styling for the faux terminal windows, better text selection color, better copy button placement. 