### PR TITLE
Unique dirs for coverage files per integration test process

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -693,8 +693,20 @@ func (Test) Coverage(ctx context.Context) error {
 	mg.CtxDeps(ctx, Test.Unit, Test.Integration)
 
 	// Convert integration GOCOVERDIR binary data to a text profile.
+	// Each test invocation writes to its own pod subdirectory under
+	// coverage/integration (see tests/common.py) to avoid a covmeta write
+	// race across parallel processes. covdata takes a comma-separated list
+	// of pod directories, so enumerate them here.
+	pods, err := filepath.Glob("coverage/integration/*")
+	if err != nil {
+		return fmt.Errorf("failed to enumerate coverage pods: %w", err)
+	}
+	inputs := "coverage/integration"
+	if len(pods) > 0 {
+		inputs = strings.Join(pods, ",")
+	}
 	if err := sh.Run("go", "tool", "covdata", "textfmt",
-		"-i=coverage/integration",
+		"-i="+inputs,
 		"-o=coverage/integration.profile",
 	); err != nil {
 		return fmt.Errorf("failed to convert integration coverage to text: %w", err)

--- a/tests/common.py
+++ b/tests/common.py
@@ -52,6 +52,10 @@ _GHOSTUNNEL_BINARY = os.path.join(_ROOT_DIR, 'ghostunnel.cover.exe' if IS_WINDOW
 _COVERAGE_DIR = os.path.join(_ROOT_DIR, 'coverage')
 os.makedirs(_COVERAGE_DIR, exist_ok=True)
 
+# Monotonic counter used to give each ghostunnel invocation a unique
+# GOCOVERDIR pod subdirectory (see run_ghostunnel).
+_coverage_pod = 0
+
 _SO_REUSEPORT = getattr(socket, 'SO_REUSEPORT', None)
 
 # Holds reservation sockets for ports allocated by get_free_port()
@@ -135,7 +139,17 @@ def run_ghostunnel(args, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, pre
     # Set GOCOVERDIR for binary-format coverage data (merged by go tool covdata).
     # The binary is built with go build -cover and writes coverage counters
     # to this directory on exit (including signal-triggered exits).
-    integration_coverdir = os.path.join(_COVERAGE_DIR, 'integration')
+    #
+    # Each invocation gets its own pod subdirectory. All tests run the same
+    # binary, so they all emit an identically-named covmeta.<hash> file via
+    # write-tmp-then-rename; sharing one directory across the ~NumCPU parallel
+    # test processes makes that rename race, and the runtime prints the failure
+    # to stderr (which trips test-server-quiet-all-logs). Per-invocation dirs
+    # give each process a private covmeta target; covdata merges the pods later.
+    global _coverage_pod
+    _coverage_pod += 1
+    integration_coverdir = os.path.join(
+        _COVERAGE_DIR, 'integration', '{0}-{1}'.format(os.getpid(), _coverage_pod))
     os.makedirs(integration_coverdir, exist_ok=True)
     env["GOCOVERDIR"] = integration_coverdir
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -53,8 +53,26 @@ _COVERAGE_DIR = os.path.join(_ROOT_DIR, 'coverage')
 os.makedirs(_COVERAGE_DIR, exist_ok=True)
 
 # Monotonic counter used to give each ghostunnel invocation a unique
-# GOCOVERDIR pod subdirectory (see run_ghostunnel).
+# GOCOVERDIR pod subdirectory (see coverage_pod_dir).
 _coverage_pod = 0
+
+
+def coverage_pod_dir():
+    """Create a fresh GOCOVERDIR pod subdirectory for one ghostunnel invocation.
+
+    Each invocation gets its own pod subdirectory. All tests run the same
+    binary, so they all emit an identically-named covmeta.<hash> file via
+    write-tmp-then-rename; sharing one directory across the ~NumCPU parallel
+    test processes makes that rename race, and the runtime prints the failure
+    to stderr (which trips test-server-quiet-all-logs). Per-invocation dirs
+    give each process a private covmeta target; covdata merges the pods later.
+    """
+    global _coverage_pod
+    _coverage_pod += 1
+    pod_dir = os.path.join(
+        _COVERAGE_DIR, 'integration', '{0}-{1}'.format(os.getpid(), _coverage_pod))
+    os.makedirs(pod_dir, exist_ok=True)
+    return pod_dir
 
 _SO_REUSEPORT = getattr(socket, 'SO_REUSEPORT', None)
 
@@ -139,19 +157,7 @@ def run_ghostunnel(args, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, pre
     # Set GOCOVERDIR for binary-format coverage data (merged by go tool covdata).
     # The binary is built with go build -cover and writes coverage counters
     # to this directory on exit (including signal-triggered exits).
-    #
-    # Each invocation gets its own pod subdirectory. All tests run the same
-    # binary, so they all emit an identically-named covmeta.<hash> file via
-    # write-tmp-then-rename; sharing one directory across the ~NumCPU parallel
-    # test processes makes that rename race, and the runtime prints the failure
-    # to stderr (which trips test-server-quiet-all-logs). Per-invocation dirs
-    # give each process a private covmeta target; covdata merges the pods later.
-    global _coverage_pod
-    _coverage_pod += 1
-    integration_coverdir = os.path.join(
-        _COVERAGE_DIR, 'integration', '{0}-{1}'.format(os.getpid(), _coverage_pod))
-    os.makedirs(integration_coverdir, exist_ok=True)
-    env["GOCOVERDIR"] = integration_coverdir
+    env["GOCOVERDIR"] = coverage_pod_dir()
 
     # Run ghostunnel directly with args (binary built with go build -cover)
     cmd = [_GHOSTUNNEL_BINARY] + args

--- a/tests/test-client-launchd-socket-activation.py
+++ b/tests/test-client-launchd-socket-activation.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 from common import (LISTEN_PORT, STATUS_PORT, RootCert, TcpClient,
                     print_ok, require_platform, _GHOSTUNNEL_BINARY,
-                    _COVERAGE_DIR, _WORK_DIR, _extra_port_sockets)
+                    _WORK_DIR, _extra_port_sockets, coverage_pod_dir)
 
 require_platform('Darwin')
 
@@ -20,8 +20,7 @@ LABEL = 'dev.ghostunnel.test.launchd.{0}'.format(os.getpid())
 PLIST_PATH = os.path.join(_WORK_DIR, '{0}.plist'.format(LABEL))
 UID = os.getuid()
 DOMAIN = 'gui/{0}'.format(UID)
-COVERDIR = os.path.join(_COVERAGE_DIR, 'integration')
-os.makedirs(COVERDIR, exist_ok=True)
+COVERDIR = coverage_pod_dir()
 
 PLIST = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"

--- a/tests/test-client-systemd-unix-socket-persists.py
+++ b/tests/test-client-systemd-unix-socket-persists.py
@@ -18,7 +18,7 @@ import socket as pysocket
 import subprocess
 import tempfile
 import time
-from common import LOCALHOST, RootCert, print_ok, require_platform, _GHOSTUNNEL_BINARY, _COVERAGE_DIR
+from common import LOCALHOST, RootCert, print_ok, require_platform, _GHOSTUNNEL_BINARY, coverage_pod_dir
 
 require_platform('Linux')
 
@@ -41,9 +41,7 @@ try:
 
     # Coverage env mirrors run_ghostunnel().
     env = os.environ.copy()
-    integration_coverdir = os.path.join(_COVERAGE_DIR, 'integration')
-    os.makedirs(integration_coverdir, exist_ok=True)
-    env['GOCOVERDIR'] = integration_coverdir
+    env['GOCOVERDIR'] = coverage_pod_dir()
     env['LISTEN_FDS'] = '1'
     env['LISTEN_FDNAMES'] = 'client'
 


### PR DESCRIPTION
Create unique dirs for coverage files per integration test process to fix a rare albeit real race condition on writing coverage files when integration tests run in parallel. Previously, tests wrote to the same file, which on occasion could case the coverage file to not show up as we'd lose the rename race. 