### PR TITLE
Better bounding for SPIFFE Workload API timeouts

### DIFF
--- a/certloader/spiffe_tls_config.go
+++ b/certloader/spiffe_tls_config.go
@@ -36,6 +36,8 @@ type spiffeTLSConfigSource struct {
 }
 
 // TLSConfigSourceFromWorkloadAPI creates a TLSConfigSource that uses the SPIFFE Workload API.
+// initTimeout bounds how long the first certificate fetch (NewX509Source) may block at startup.
+// A value of 0 (or negative) means wait indefinitely — the old behavior before the timeout was introduced.
 func TLSConfigSourceFromWorkloadAPI(addr string, clientDisableAuth bool, initTimeout time.Duration, logger *log.Logger) (TLSConfigSource, error) {
 	client, err := spiffeApi.New(
 		context.Background(),
@@ -77,7 +79,7 @@ func (s *spiffeTLSConfigSource) Close() error {
 func (s *spiffeTLSConfigSource) newConfig(base *tls.Config) (*spiffeTLSConfig, error) {
 	// NewX509Source blocks until the first update is received from the Workload
 	// API. Bound that wait so an unreachable agent surfaces as an error instead
-	// of hanging forever.
+	// of hanging forever. initTimeout <= 0 means wait indefinitely (no deadline).
 	ctx := context.Background()
 	if s.initTimeout > 0 {
 		var cancel context.CancelFunc

--- a/docs/certificates/spiffe-workload-api.md
+++ b/docs/certificates/spiffe-workload-api.md
@@ -76,6 +76,14 @@ ghostunnel client \
     --verify-uri spiffe://domain.test/backend
 ```
 
+## Startup Timeout
+
+At startup, Ghostunnel waits up to `--use-workload-api-timeout` (default `10m`) for the
+first certificate to arrive from the Workload API before treating it as a fatal error. This
+covers deployments where the SPIRE agent is slow to attest at boot (e.g. fresh nodes, or
+ghostunnel racing spire-agent under systemd or Kubernetes). Setting the flag to `0` restores
+the pre-v1.11.1 behavior of waiting indefinitely.
+
 ## Trust Bundle Updates
 
 When using the Workload API, Ghostunnel automatically watches for updates

--- a/docs/getting-started/flags.md
+++ b/docs/getting-started/flags.md
@@ -26,6 +26,7 @@ supported file formats and chain ordering.
 | `--cacert CACERT` | Path to CA bundle file (PEM/X509). Uses system trust store by default. |
 | `--use-workload-api` | Certificate and root CAs are retrieved via the SPIFFE Workload API. See [SPIFFE]({{< ref "spiffe-workload-api.md" >}}). |
 | `--use-workload-api-addr ADDR` | Retrieve certificates and root CAs via the SPIFFE Workload API at the specified address (implies `--use-workload-api`). See [SPIFFE]({{< ref "spiffe-workload-api.md" >}}). |
+| `--use-workload-api-timeout DURATION` | Timeout for the initial certificate fetch from the SPIFFE Workload API at startup (default `10m`). Set to `0` to wait indefinitely, which restores the behavior prior to v1.11.1. See [SPIFFE]({{< ref "spiffe-workload-api.md" >}}). |
 
 ### Keychain
 

--- a/docs/reference/manpage-darwin.md
+++ b/docs/reference/manpage-darwin.md
@@ -241,6 +241,10 @@ via the SPIFFE Workload API
 retrieved via the SPIFFE Workload API at the specified address (implies
 --use-workload-api)
 
+**--use-workload-api-timeout=10m** Timeout for the initial certificate
+fetch from the SPIFFE Workload API at startup (set to 0 to wait
+indefinitely)
+
 **--timed-reload=DURATION** Reload keystores every given interval (e.g.
 300s), refresh listener/client on changes.
 

--- a/main.go
+++ b/main.go
@@ -127,8 +127,9 @@ var (
 	keyPath            = app.Flag("key", "Path to certificate private key (PEM with private key).").PlaceHolder("PATH").Envar("KEY_PATH").String()
 	keystorePass       = app.Flag("storepass", "Password for keystore (PKCS#12 or JCEKS; optional for PKCS#12).").PlaceHolder("PASS").Envar("KEYSTORE_PASS").String()
 	caBundlePath       = app.Flag("cacert", "Path to CA bundle file (PEM/X509). Uses system trust store by default.").Envar("CACERT_PATH").String()
-	useWorkloadAPI     = app.Flag("use-workload-api", "If true, certificate and root CAs are retrieved via the SPIFFE Workload API").Bool()
-	useWorkloadAPIAddr = app.Flag("use-workload-api-addr", "If set, certificates and root CAs are retrieved via the SPIFFE Workload API at the specified address (implies --use-workload-api)").Envar("SPIFFE_ENDPOINT_SOCKET").PlaceHolder("ADDR").String()
+	useWorkloadAPI        = app.Flag("use-workload-api", "If true, certificate and root CAs are retrieved via the SPIFFE Workload API").Bool()
+	useWorkloadAPIAddr    = app.Flag("use-workload-api-addr", "If set, certificates and root CAs are retrieved via the SPIFFE Workload API at the specified address (implies --use-workload-api)").Envar("SPIFFE_ENDPOINT_SOCKET").PlaceHolder("ADDR").String()
+	useWorkloadAPITimeout = app.Flag("use-workload-api-timeout", "Timeout for the initial certificate fetch from the SPIFFE Workload API at startup (set to 0 to wait indefinitely)").Default("10m").Duration()
 
 	// Deprecated cipher suite flags
 	enabledCipherSuites     = app.Flag("cipher-suites", "Set of cipher suites to enable, comma-separated, in order of preference (AES, CHACHA).").Hidden().Default("AES,CHACHA").String()
@@ -274,6 +275,9 @@ func validateFlags(app *kingpin.Application) error {
 	}
 	if *connectTimeout == 0 {
 		return fmt.Errorf("--connect-timeout duration must not be zero")
+	}
+	if *useWorkloadAPITimeout < 0 {
+		return fmt.Errorf("--use-workload-api-timeout duration must not be negative (use 0 to wait indefinitely)")
 	}
 	return nil
 }
@@ -1207,7 +1211,7 @@ func proxyLoggerFlags(flags []string) int {
 func getTLSConfigSource(disableAuth bool) (certloader.TLSConfigSource, error) {
 	if *useWorkloadAPI {
 		logger.Printf("using SPIFFE Workload API as certificate source")
-		source, err := certloader.TLSConfigSourceFromWorkloadAPI(*useWorkloadAPIAddr, disableAuth, *connectTimeout, logger)
+		source, err := certloader.TLSConfigSourceFromWorkloadAPI(*useWorkloadAPIAddr, disableAuth, *useWorkloadAPITimeout, logger)
 		if err != nil {
 			logger.Printf("error: unable to create workload API TLS source: %s\n", err)
 			return nil, err

--- a/main_test.go
+++ b/main_test.go
@@ -85,6 +85,7 @@ func TestFlagValidation(t *testing.T) {
 		*metricsURL = ""
 		*serverStatusTargetAddress = ""
 		*connectTimeout = 10 * time.Second
+		*useWorkloadAPITimeout = 10 * time.Minute
 	}
 	defer reset()
 
@@ -107,6 +108,14 @@ func TestFlagValidation(t *testing.T) {
 	reset()
 	*connectTimeout = 0
 	assert.NotNil(t, validateFlags(nil), "invalid --connect-timeout should be rejected")
+
+	reset()
+	*useWorkloadAPITimeout = -1
+	assert.NotNil(t, validateFlags(nil), "negative --use-workload-api-timeout should be rejected")
+
+	reset()
+	*useWorkloadAPITimeout = 0
+	assert.Nil(t, validateFlags(nil), "zero --use-workload-api-timeout (wait indefinitely) should be accepted")
 }
 
 func TestServerFlagValidation(t *testing.T) {


### PR DESCRIPTION
Better bounding for SPIFFE Workload API timeouts by exposing via flag. Current released version waits indefinitely, which is too much. Prior change in master updated this to match close timeout, which is kind of ok but not great. This change updates it to use a separate flag with a generous default timeout. 