### PR TITLE
Raise default half-close timeout to 60s

### DIFF
--- a/docs/getting-started/flags.md
+++ b/docs/getting-started/flags.md
@@ -56,7 +56,7 @@ See [HSM/PKCS#11]({{< ref "hsm-pkcs11.md" >}}).
 | `--timed-reload DURATION` | | Reload keystores every given interval, refresh listener/client on changes. |
 | `--shutdown-timeout DURATION` | `5m` | Process shutdown timeout. Terminates after timeout even if connections are still open. |
 | `--connect-timeout DURATION` | `10s` | Timeout for establishing connections and handshakes. |
-| `--close-timeout DURATION` | `1s` | Timeout for closing connections when one side terminates. Zero means immediate closure. |
+| `--close-timeout DURATION` | `60s` | Timeout for closing connections when one side terminates. Zero means immediate closure. Default raised from `1s` to `60s` in v1.11.1. |
 | `--max-conn-lifetime DURATION` | `0s` | Maximum lifetime for connections post handshake. Zero means infinite. |
 | `--max-concurrent-conns N` | `0` | Maximum number of concurrent connections. Zero means infinite. |
 

--- a/docs/reference/manpage-darwin.md
+++ b/docs/reference/manpage-darwin.md
@@ -250,7 +250,7 @@ timeout even if connections still open.
 **--connect-timeout=10s** Timeout for establishing connections,
 handshakes.
 
-**--close-timeout=1s** Timeout for closing connections when one side
+**--close-timeout=60s** Timeout for closing connections when one side
 terminates. Zero means immediate closure.
 
 **--max-conn-lifetime=0s** Maximum lifetime for connections post

--- a/docs/reference/manpage-linux.md
+++ b/docs/reference/manpage-linux.md
@@ -250,7 +250,7 @@ timeout even if connections still open.
 **--connect-timeout=10s** Timeout for establishing connections,
 handshakes.
 
-**--close-timeout=1s** Timeout for closing connections when one side
+**--close-timeout=60s** Timeout for closing connections when one side
 terminates. Zero means immediate closure.
 
 **--max-conn-lifetime=0s** Maximum lifetime for connections post

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ var (
 	timedReload            = app.Flag("timed-reload", "Reload keystores every given interval (e.g. 300s), refresh listener/client on changes.").PlaceHolder("DURATION").Duration()
 	processShutdownTimeout = app.Flag("shutdown-timeout", "Process shutdown timeout. Terminates after timeout even if connections still open.").Default("5m").Duration()
 	connectTimeout         = app.Flag("connect-timeout", "Timeout for establishing connections, handshakes.").Default("10s").Duration()
-	closeTimeout           = app.Flag("close-timeout", "Timeout for closing connections when one side terminates. Zero means immediate closure.").Default("1s").Duration()
+	closeTimeout           = app.Flag("close-timeout", "Timeout for closing connections when one side terminates. Zero means immediate closure.").Default("60s").Duration()
 	maxConnLifetime        = app.Flag("max-conn-lifetime", "Maximum lifetime for connections post handshake, no matter what. Zero means infinite.").Default("0s").Duration()
 	maxConcurrentConns     = app.Flag("max-concurrent-conns", "Maximum number of concurrent connections to handle in the proxy. Zero means infinite.").Default("0").Uint32()
 


### PR DESCRIPTION
More generous half-close timeout, to accommodate larger payloads still in flight after half-close. Going to update this to be an idle timeout in the future, with deadline pushed out as long as data is flowing (but that's a larger change and will not be in the next point release, future TODO). 