### PR TITLE
Allow unix socket targets in client mode

### DIFF
--- a/docs/getting-started/flags.md
+++ b/docs/getting-started/flags.md
@@ -173,7 +173,7 @@ for `systemd:NAME` and `launchd:NAME` addresses.
 | Flag | Description |
 |------|-------------|
 | `--listen ADDR` | Address and port to listen on (`HOST:PORT`, `unix:PATH`, `systemd:NAME`, or `launchd:NAME`). |
-| `--target ADDR` | Address to forward connections to (must be `HOST:PORT`). |
+| `--target ADDR` | Address to forward connections to (`HOST:PORT` or `unix:PATH`). A `unix:PATH` target has no hostname, so set `--override-server-name` for hostname verification. |
 
 ### Connection
 

--- a/docs/reference/manpage-darwin.md
+++ b/docs/reference/manpage-darwin.md
@@ -389,7 +389,8 @@ Client mode (plain TCP/UNIX listener -\> TLS target). **--listen=ADDR**
 Address and port to listen on (can be HOST:PORT, unix:PATH, systemd:NAME
 or launchd:NAME).
 
-**--target=ADDR** Address to forward connections to (must be HOST:PORT).
+**--target=ADDR** Address to forward connections to (can be HOST:PORT or
+unix:PATH).
 
 **--unsafe-listen** If set, does not limit listen to localhost,
 127.0.0.1, \[::1\], or UNIX sockets.

--- a/docs/reference/manpage-linux.md
+++ b/docs/reference/manpage-linux.md
@@ -378,7 +378,8 @@ Client mode (plain TCP/UNIX listener -\> TLS target). **--listen=ADDR**
 Address and port to listen on (can be HOST:PORT, unix:PATH, systemd:NAME
 or launchd:NAME).
 
-**--target=ADDR** Address to forward connections to (must be HOST:PORT).
+**--target=ADDR** Address to forward connections to (can be HOST:PORT or
+unix:PATH).
 
 **--unsafe-listen** If set, does not limit listen to localhost,
 127.0.0.1, \[::1\], or UNIX sockets.

--- a/docs/security/access-flags.md
+++ b/docs/security/access-flags.md
@@ -112,7 +112,10 @@ replace hostname verification entirely rather than adding to it: the
 `--use-workload-api` is set, hostname verification is replaced by SPIFFE
 authentication — peers are verified as presenting a valid X509-SVID, so use
 `--verify-uri` to pin the expected SPIFFE ID), and `--verify-spki-pin` (see below,
-which authenticates the server by its SPKI pin alone).
+which authenticates the server by its SPKI pin alone). A `unix:PATH` target
+carries no hostname, so unless one of those exceptions is in effect,
+`--override-server-name` must be set to give hostname verification a name to
+check; connections fail otherwise.
 
 When multiple verification flags are specified, they are OR'd together: a
 connection is allowed if at least one flag matches (and hostname verification

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ var (
 	clientCommand       = app.Command("client", "Client mode (plain TCP/UNIX listener -> TLS target).")
 	clientListenAddress = clientCommand.Flag("listen", "Address and port to listen on (can be HOST:PORT, unix:PATH, systemd:NAME or launchd:NAME).").PlaceHolder("ADDR").Required().String()
 	// Note: can't use .TCP() for clientForwardAddress because we need to set the original string in tls.Config.ServerName.
-	clientForwardAddress = clientCommand.Flag("target", "Address to forward connections to (must be HOST:PORT).").PlaceHolder("ADDR").Required().String()
+	clientForwardAddress = clientCommand.Flag("target", "Address to forward connections to (can be HOST:PORT or unix:PATH).").PlaceHolder("ADDR").Required().String()
 	clientUnsafeListen   = clientCommand.Flag("unsafe-listen", "If set, does not limit listen to localhost, 127.0.0.1, [::1], or UNIX sockets.").Bool()
 	clientServerName     = clientCommand.Flag("override-server-name", "If set, overrides the server name used for hostname verification.").PlaceHolder("NAME").String()
 	clientProxy          = clientCommand.Flag("proxy", "If set, connect to target over given proxy (HTTP CONNECT or SOCKS5). Must be a proxy URL.").PlaceHolder("URL").URL()
@@ -530,8 +530,8 @@ func validateClientTarget() error {
 	if err != nil {
 		return fmt.Errorf("invalid --target address: %w", err)
 	}
-	if network != "tcp" {
-		return fmt.Errorf("invalid --target network %q: client mode requires a HOST:PORT TCP target", network)
+	if !socket.IsDialableNetwork(network) {
+		return fmt.Errorf("invalid --target network %q: only tcp and unix targets are supported (systemd:/launchd: cannot be dialed)", network)
 	}
 	return nil
 }
@@ -826,7 +826,8 @@ func run(args []string) error {
 
 		// NOTE: We don't provide a target status address here because this handler
 		// is for the client /_status endpoint, its target will be a Ghostunnel in
-		// server mode, and thus this should be a (default) TCP check.
+		// server mode, and thus this should be a (default) connect check via the
+		// backend dialer (which handles both tcp and unix targets).
 		status := newStatusHandler(dial, command, *clientListenAddress, *clientForwardAddress, "")
 		env := &Environment{
 			status:          status,

--- a/main_test.go
+++ b/main_test.go
@@ -608,16 +608,12 @@ func TestServerBackendDialerAcceptsUnix(t *testing.T) {
 	assert.NotNil(t, dial, "unix: target should produce a dialer")
 }
 
-func TestValidateClientTargetRejectsUnix(t *testing.T) {
+func TestValidateClientTargetAcceptsUnix(t *testing.T) {
 	original := *clientForwardAddress
 	defer func() { *clientForwardAddress = original }()
 
-	*clientForwardAddress = "unix:/tmp/foo"
-	err := validateClientTarget()
-	assert.NotNil(t, err, "unix: target should be rejected for client mode")
-	if err != nil {
-		assert.Contains(t, err.Error(), "unix", "error message should mention the offending network")
-	}
+	*clientForwardAddress = "unix:/tmp/ghostunnel-target-test.sock"
+	assert.Nil(t, validateClientTarget(), "unix: target should be accepted for client mode")
 }
 
 func TestValidateClientTargetRejectsSystemd(t *testing.T) {

--- a/tests/common.py
+++ b/tests/common.py
@@ -1064,6 +1064,61 @@ class UnixServer(MySocket):
         self.listener = None
         os.remove(self.socket_path)
 
+
+class TlsUnixServer(MySocket):
+    """TLS server listening on a unix socket, like TlsServer but with a
+    unix socket instead of a TCP port. Used as the backend for testing
+    unix socket targets in client mode."""
+
+    def __init__(
+            self,
+            cert,
+            ca,
+            cert_reqs=ssl.CERT_REQUIRED):
+        super().__init__()
+        self.cert = cert
+        self.ca = ca
+        self.cert_reqs = cert_reqs
+        self.socket_path = os.path.join(mkdtemp(dir=_test_tmpdir()), 'ghostunnel-test-socket')
+        self.tls_listener = None
+
+    def get_socket_path(self):
+        return self.socket_path
+
+    def listen(self):
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.settimeout(TIMEOUT)
+        listener.bind(self.socket_path)
+        listener.listen(1)
+        self.tls_listener = wrap_socket(listener,
+                                            server_side=True,
+                                            keyfile='{0}.key'.format(
+                                                self.cert),
+                                            certfile='{0}.crt'.format(
+                                                self.cert),
+                                            ca_certs='{0}.crt'.format(self.ca),
+                                            cert_reqs=self.cert_reqs)
+
+    def accept(self):
+        self.socket, _ = self.tls_listener.accept()
+        self.socket.settimeout(TIMEOUT)
+        self.tls_listener.close()
+        self.tls_listener = None
+
+    def validate_client_cert(self, ou):
+        actual = _get_ou(self.socket.getpeercert())
+        if actual == ou:
+            return
+        raise Exception("did not connect to expected peer: got {}, wanted: {}".format(
+                        actual, ou))
+
+    def cleanup(self):
+        super().cleanup()
+        if self.tls_listener:
+            self.tls_listener.close()
+        self.tls_listener = None
+        os.remove(self.socket_path)
+
 ######################### SocketPair #########################
 
 # This is whacky but works. This class represents a pair of sockets which

--- a/tests/test-client-unix-socket-target.py
+++ b/tests/test-client-unix-socket-target.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+"""
+Ensures ghostunnel in client mode can connect to a unix socket target.
+"""
+
+from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpClient, TlsUnixServer, print_ok, run_ghostunnel, require_platform, terminate, LISTEN_PORT
+
+require_platform('Darwin', 'Linux', 'BSD')
+
+ghostunnel = None
+try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server')
+    root.create_signed_cert('client')
+
+    # start ghostunnel
+    server = TlsUnixServer('server', 'root')
+    ghostunnel = run_ghostunnel(['client',
+                                 '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+                                 '--target=unix:{0}'.format(server.get_socket_path()),
+                                 '--override-server-name=server',
+                                 '--keystore=client.p12',
+                                 '--cacert=root.crt',
+                                 '--status={0}:{1}'.format(LOCALHOST,
+                                                           STATUS_PORT)])
+
+    # connect with client, confirm that the tunnel is up
+    pair = SocketPair(TcpClient(LISTEN_PORT), server)
+    server.validate_client_cert('client')
+    pair.validate_can_send_from_client(
+        "hello world", "1: client -> server")
+    pair.validate_can_send_from_server(
+        "hello world", "1: server -> client")
+    pair.validate_closing_client_closes_server(
+        "1: client closed -> server closed")
+
+    print_ok("OK")
+finally:
+    terminate(ghostunnel)


### PR DESCRIPTION
validateClientTarget (added in #762) rejects any client `--target` that isn't tcp, including `unix:PATH`. That check is stricter than the dialer underneath: the client backend dialer hands the parsed network straight to net.Dialer, which dials unix sockets natively, and unix targets worked in client mode through v1.10.0. It also made client `--target` the only address flag where unix sockets are banned, since server mode explicitly allows `--target unix:PATH` and both modes accept `--listen unix:PATH`.

This relaxes the check to socket.IsDialableNetwork, matching validateServerTarget, so tcp and unix targets pass while the listen-only systemd:/launchd: schemes stay rejected. Nothing else needed to change: landlock already grants access for unix client targets (clientForwardAddress goes through ruleFromStringAddress), and the /_status backend check uses the backend dialer as-is, which handles both networks.

The use case, which we run in production: sidecar setups where two processes under mutually untrusting uids rendezvous on a shared unix socket instead of a localhost port, with mTLS over the socket and socket file permissions acting as the transport ACL. The server half of that pattern (TLS listener on `unix:PATH`) has always been supported; v1.11.0 broke the client half.

Two caveats worth noting. A unix target carries no hostname, so `--override-server-name` is needed for hostname verification to have a name to check (unless workload API or SPKI pin verification replaces hostname verification); without it the connection fails closed with a clear TLS error. The docs now say so. And `--proxy` combined with a unix target passes validation but fails per connection at dial time, since the CONNECT/SOCKS dialers are tcp only; that's pre-existing dialer behavior, not made worse here.

Tested with a unit test mirroring the existing server-side one, plus a new integration test (test-client-unix-socket-target.py, using a TlsUnixServer harness class along the lines of TlsServer/UnixServer). The full test suite passes, and I also smoke-tested the client end to end against a TLS server on a unix socket.
