### PR TITLE
Fix v1.11.1 docs for --use-workload-api-timeout

### DIFF
--- a/docs/reference/manpage-linux.md
+++ b/docs/reference/manpage-linux.md
@@ -241,6 +241,10 @@ via the SPIFFE Workload API
 retrieved via the SPIFFE Workload API at the specified address (implies
 --use-workload-api)
 
+**--use-workload-api-timeout=10m** Timeout for the initial certificate
+fetch from the SPIFFE Workload API at startup (set to 0 to wait
+indefinitely)
+
 **--timed-reload=DURATION** Reload keystores every given interval (e.g.
 300s), refresh listener/client on changes.
 

--- a/releases/v1.11.1.md
+++ b/releases/v1.11.1.md
@@ -22,7 +22,7 @@ prerelease: false
 
 ## Bug Fixes
 
-* **SPIFFE Workload API startup hang.** Building a TLS config waited on the first Workload API update with an unbounded context, so an unreachable SPIFFE agent hung Ghostunnel forever instead of surfacing a startup error. The initial fetch is now bounded by the connect timeout (#786, #793).
+* **SPIFFE Workload API startup hang.** Building a TLS config waited on the first Workload API update with an unbounded context, so an unreachable SPIFFE agent hung Ghostunnel forever instead of surfacing a startup error. The initial fetch is now bounded by the new `--use-workload-api-timeout` flag (default `10m`); set it to `0` to wait indefinitely, restoring the previous behavior (#786, #793).
 * **PKCS#11 reload key mismatch.** Reload now keeps the previous key pair when a freshly read certificate no longer matches the cached HSM private key, instead of publishing a broken cert/key pair (#786).
 * **Keychain resource leaks and races.** Reload now closes the OS certificate store and releases unused identities (previously leaked on every startup and reload), cached certificate access in the macOS keychain identity is properly synchronized across concurrent handshakes, and Windows security status codes are compared without sign extension so errors map correctly (#786).
 * **Proxy teardown and error accounting.** TLS connections are half-closed during copy teardown, backend dial and PROXY protocol header write failures are counted as errors, connection resets and broken pipes are treated as expected teardown, and Ghostunnel fails closed when PROXY protocol TLS metadata cannot be encoded (#786).
@@ -47,3 +47,4 @@ prerelease: false
 |------|-------------|
 | `--allow-spki-pin PIN` | (Server) Allow clients matching the given SPKI pin of the form `<algo>:<base64-digest>` (repeatable) |
 | `--verify-spki-pin PIN` | (Client) Verify the server matches the given SPKI pin of the form `<algo>:<base64-digest>` (repeatable) |
+| `--use-workload-api-timeout DURATION` | Timeout for the initial certificate fetch from the SPIFFE Workload API at startup (default `10m`, set to `0` to wait indefinitely) |


### PR DESCRIPTION
Fixes two documentation gaps left behind when #793 landed shortly before the v1.11.1 release was tagged.

#793 replaced the connect-timeout bound on the initial SPIFFE Workload API fetch (from #786) with a dedicated `--use-workload-api-timeout` flag (default `10m`, `0` = wait indefinitely). The release notes had been written earlier that day against the #786 state and weren't updated, and only the macOS man page was regenerated.

Changes:

- **`releases/v1.11.1.md`**: The bug-fix bullet claimed the initial fetch is "bounded by the connect timeout" — the shipped release actually bounds it with `--use-workload-api-timeout` (default `10m`, not the 10s connect timeout). Updated the wording and added the flag to the "New Flags" table, which previously listed only the SPKI pinning flags.
- **`docs/reference/manpage-linux.md`**: Regenerated on Linux via `go tool mage go:man`. The only diff is the missing `--use-workload-api-timeout` entry, matching what #793 already added to the macOS man page.

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAGkVHzBQeCba51kXgrj4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAGkVHzBQeCba51kXgrj4G)_