### PR TITLE
Add release notes for v1.11.2

### DIFF
--- a/releases/v1.11.2.md
+++ b/releases/v1.11.2.md
@@ -1,0 +1,15 @@
+---
+title: v1.11.2
+date: 2026-07-25
+prerelease: false
+---
+
+Bug fix release.
+
+## Bug Fixes
+
+* **UNIX socket targets in client mode restored.** The stricter `--target` validation added in v1.11.0 (#762) rejected `unix:PATH` targets in client mode, even though they had worked through v1.10.0 (and remained supported in server mode). Client mode now accepts both `HOST:PORT` and `unix:PATH` targets again, while the listen-only `systemd:`/`launchd:` schemes stay rejected at startup. This is useful for sidecar setups where two processes rendezvous on a shared socket instead of a localhost port, with mTLS running over the socket. Note that a `unix:PATH` target carries no hostname, so set `--override-server-name` to give hostname verification a name to check (unless `--use-workload-api` or `--verify-spki-pin` replaces hostname verification) (#799, thanks to @molchalih).
+
+## Other
+
+* **Documentation fixes for `--use-workload-api-timeout`.** The v1.11.1 release notes and the Linux man page now correctly document the `--use-workload-api-timeout` flag introduced in that release, instead of describing the initial SPIFFE Workload API fetch as bounded by the connect timeout (#800).


### PR DESCRIPTION
Two changes since v1.11.1: the client-mode unix:PATH target regression
fix (#799) and the --use-workload-api-timeout documentation fix (#800).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RUX98Rk1UnH9xGDp9deD97