### PR TITLE
add --alpn cli option for ALPN protocols

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,14 +122,15 @@ var (
 	clientDisableAuth    = clientCommand.Flag("disable-authentication", "Disable client authentication, no certificate will be provided to the server.").Default("false").Bool()
 
 	// TLS options
-	keystorePath       = app.Flag("keystore", "Path to keystore (combined PEM with cert/key, or PKCS12 keystore).").PlaceHolder("PATH").Envar("KEYSTORE_PATH").String()
-	certPath           = app.Flag("cert", "Path to certificate (PEM with certificate chain).").PlaceHolder("PATH").Envar("CERT_PATH").String()
-	keyPath            = app.Flag("key", "Path to certificate private key (PEM with private key).").PlaceHolder("PATH").Envar("KEY_PATH").String()
-	keystorePass       = app.Flag("storepass", "Password for keystore (PKCS#12 or JCEKS; optional for PKCS#12).").PlaceHolder("PASS").Envar("KEYSTORE_PASS").String()
-	caBundlePath       = app.Flag("cacert", "Path to CA bundle file (PEM/X509). Uses system trust store by default.").Envar("CACERT_PATH").String()
+	keystorePath          = app.Flag("keystore", "Path to keystore (combined PEM with cert/key, or PKCS12 keystore).").PlaceHolder("PATH").Envar("KEYSTORE_PATH").String()
+	certPath              = app.Flag("cert", "Path to certificate (PEM with certificate chain).").PlaceHolder("PATH").Envar("CERT_PATH").String()
+	keyPath               = app.Flag("key", "Path to certificate private key (PEM with private key).").PlaceHolder("PATH").Envar("KEY_PATH").String()
+	keystorePass          = app.Flag("storepass", "Password for keystore (PKCS#12 or JCEKS; optional for PKCS#12).").PlaceHolder("PASS").Envar("KEYSTORE_PASS").String()
+	caBundlePath          = app.Flag("cacert", "Path to CA bundle file (PEM/X509). Uses system trust store by default.").Envar("CACERT_PATH").String()
 	useWorkloadAPI        = app.Flag("use-workload-api", "If true, certificate and root CAs are retrieved via the SPIFFE Workload API").Bool()
 	useWorkloadAPIAddr    = app.Flag("use-workload-api-addr", "If set, certificates and root CAs are retrieved via the SPIFFE Workload API at the specified address (implies --use-workload-api)").Envar("SPIFFE_ENDPOINT_SOCKET").PlaceHolder("ADDR").String()
 	useWorkloadAPITimeout = app.Flag("use-workload-api-timeout", "Timeout for the initial certificate fetch from the SPIFFE Workload API at startup (set to 0 to wait indefinitely)").Default("10m").Duration()
+	alpn                  = app.Flag("alpn", "Prioritized comma-separated list of protocols to negotiate via ALPN").PlaceHolder("PROTOS").String()
 
 	// Deprecated cipher suite flags
 	enabledCipherSuites     = app.Flag("cipher-suites", "Set of cipher suites to enable, comma-separated, in order of preference (AES, CHACHA).").Hidden().Default("AES,CHACHA").String()
@@ -873,7 +874,7 @@ func loadOPAPolicy(allowPolicy, allowQuery string) (policy.Policy, error) {
 // connections. This is useful for the purpose of replacing certificates
 // in-place without having to take downtime, e.g. if a certificate is expiring.
 func serverListen(env *Environment, regoPolicy policy.Policy) error {
-	config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
+	config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites, *alpn)
 	if err != nil {
 		logger.Printf("error trying to read CA bundle: %s", err)
 		return err
@@ -1068,7 +1069,7 @@ func (env *Environment) serveStatus() error {
 	}
 
 	if network == "tcp" && https && env.tlsConfigSource.CanServe() {
-		config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
+		config, err := buildServerConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites, "")
 		if err != nil {
 			return err
 		}
@@ -1118,7 +1119,7 @@ func clientBackendDialer(
 	network, address, host string,
 ) (proxy.DialFunc, policy.Policy, error) {
 
-	config, err := buildClientConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites)
+	config, err := buildClientConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites, *alpn)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tls.go
+++ b/tls.go
@@ -129,7 +129,7 @@ func resolveCipherSuites(spec string, allowUnsafe bool) ([]uint16, error) {
 }
 
 // buildConfig builds a generic tls.Config
-func buildConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool) (*tls.Config, error) {
+func buildConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool, nextProtos string) (*tls.Config, error) {
 	// List of cipher suite preferences:
 	// * We list ECDSA ahead of RSA to prefer ECDSA for multi-cert setups.
 	// * We list AES-128 ahead of AES-256 for performance reasons.
@@ -152,19 +152,23 @@ func buildConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe b
 		config.MaxVersion = maxVer
 	}
 
+	if nextProtos != "" {
+		config.NextProtos = strings.Split(nextProtos, ",")
+	}
+
 	return config, nil
 }
 
 // buildClientConfig builds a tls.Config for clients
-func buildClientConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool) (*tls.Config, error) {
+func buildClientConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool, nextProtos string) (*tls.Config, error) {
 	// At the moment, we don't apply any extra settings on top of the generic
 	// config for client contexts
-	return buildConfig(enabledCipherSuites, maxTLSVersion, allowUnsafe)
+	return buildConfig(enabledCipherSuites, maxTLSVersion, allowUnsafe, nextProtos)
 }
 
 // buildServerConfig builds a tls.Config for servers
-func buildServerConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool) (*tls.Config, error) {
-	config, err := buildConfig(enabledCipherSuites, maxTLSVersion, allowUnsafe)
+func buildServerConfig(enabledCipherSuites string, maxTLSVersion string, allowUnsafe bool, nextProtos string) (*tls.Config, error) {
+	config, err := buildConfig(enabledCipherSuites, maxTLSVersion, allowUnsafe, nextProtos)
 	if err != nil {
 		return nil, err
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -236,21 +236,26 @@ func TestBuildConfig(t *testing.T) {
 	defer os.Remove(tmpKeystoreSeparateCert.Name())
 	defer os.Remove(tmpKeystoreSeparateKey.Name())
 
-	_, err = buildConfig("", "", false)
+	_, err = buildConfig("", "", false, "")
 	assert.NotNil(t, err, "should fail to build config with no cipher suites")
 
-	conf, err := buildConfig("AES,CHACHA", "", false)
+	conf, err := buildConfig("AES,CHACHA", "", false, "")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.MinVersion == tls.VersionTLS12, "must have correct TLS min version")
 	assert.Equal(t, uint16(0), conf.MaxVersion, "should not set MaxVersion when maxTLSVersion is empty")
+	assert.Nil(t, conf.NextProtos, "must have empty next protos")
 
-	conf, err = buildConfig("AES,CHACHA", "TLS1.3", false)
+	conf, err = buildConfig("AES,CHACHA", "TLS1.3", false, "")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.MaxVersion == tls.VersionTLS13, "must have correct TLS max version")
 
-	_, err = buildConfig("AES,CHACHA", "invalid", false)
+	_, err = buildConfig("AES,CHACHA", "invalid", false, "")
 	assert.NotNil(t, err, "should fail to build config with invalid TLS version")
 	assert.Contains(t, err.Error(), "invalid max TLS version", "error should mention invalid TLS version")
+
+	conf, err = buildConfig("AES,CHACHA", "", false, "h3,h2,http/1.1")
+	assert.Nil(t, err, "should be able to build TLS config with next protos")
+	assert.Equal(t, []string{"h3", "h2", "http/1.1"}, conf.NextProtos, "must have correct list of next protos")
 
 	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
 	cert, err := buildCertificate("", "", "", "", tmpKeystoreSeparateCert.Name(), logger)
@@ -279,20 +284,20 @@ func TestBuildConfig(t *testing.T) {
 }
 
 func TestBuildClientConfig(t *testing.T) {
-	conf, err := buildClientConfig("AES,CHACHA", "", false)
+	conf, err := buildClientConfig("AES,CHACHA", "", false, "")
 	assert.Nil(t, err, "should be able to build client TLS config")
 	assert.True(t, conf.MinVersion == tls.VersionTLS12, "must have correct TLS min version")
 
-	conf, err = buildClientConfig("AES,CHACHA", "TLS1.2", false)
+	conf, err = buildClientConfig("AES,CHACHA", "TLS1.2", false, "")
 	assert.Nil(t, err, "should be able to build client TLS config with max version")
 	assert.Equal(t, uint16(tls.VersionTLS12), conf.MaxVersion, "must have correct max TLS version")
 
-	_, err = buildClientConfig("INVALID", "", false)
+	_, err = buildClientConfig("INVALID", "", false, "")
 	assert.NotNil(t, err, "should fail to build client config with invalid cipher suite")
 }
 
 func TestBuildServerConfig(t *testing.T) {
-	conf, err := buildServerConfig("AES,CHACHA", "", false)
+	conf, err := buildServerConfig("AES,CHACHA", "", false, "")
 	assert.Nil(t, err, "should be able to build server TLS config")
 	assert.Equal(t, tls.RequireAndVerifyClientCert, conf.ClientAuth, "server config should require client cert")
 }
@@ -334,27 +339,27 @@ func TestBuildCertificateNoCert(t *testing.T) {
 }
 
 func TestCipherSuitePreference(t *testing.T) {
-	_, err := buildConfig("XYZ", "TLS1.3", false)
+	_, err := buildConfig("XYZ", "TLS1.3", false, "")
 	assert.NotNil(t, err, "should not be able to build TLS config with invalid cipher suite option")
 
-	_, err = buildServerConfig("XYZ", "TLS1.3", false)
+	_, err = buildServerConfig("XYZ", "TLS1.3", false, "")
 	assert.NotNil(t, err, "should not be able to build server TLS config with invalid cipher suite option")
 
-	_, err = buildConfig("", "TLS1.3", false)
+	_, err = buildConfig("", "TLS1.3", false, "")
 	assert.NotNil(t, err, "should not be able to build TLS config wihout cipher suite selection")
 
-	conf, err := buildConfig("CHACHA,AES", "TLS1.3", false)
+	conf, err := buildConfig("CHACHA,AES", "TLS1.3", false, "")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_CHACHA20_POLY1305_SHA256, "expecting TLS 1.3 ChaCha20")
 
-	conf, err = buildConfig("AES,CHACHA", "TLS1.3", false)
+	conf, err = buildConfig("AES,CHACHA", "TLS1.3", false, "")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_AES_128_GCM_SHA256, "expecting TLS 1.3 AES")
 
-	_, err = buildConfig("AES,CHACHA,UNSAFE-AZURE", "TLS1.3", false)
+	_, err = buildConfig("AES,CHACHA,UNSAFE-AZURE", "TLS1.3", false, "")
 	assert.NotNil(t, err, "should not be able to build TLS config with unsafe cipher suite without flag")
 
-	conf, err = buildConfig("UNSAFE-AZURE", "TLS1.3", true)
+	conf, err = buildConfig("UNSAFE-AZURE", "TLS1.3", true, "")
 	assert.Nil(t, err, "should be able to build TLS config")
 	assert.True(t, conf.CipherSuites[0] == tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, "expecting AES")
 }
@@ -430,7 +435,7 @@ func TestValidateCipherSuitesMatchesBuildConfig(t *testing.T) {
 		*allowUnsafeCipherSuites = tc.allowUnsafe
 
 		validateErr := validateCipherSuites()
-		_, buildErr := buildConfig(tc.spec, "", tc.allowUnsafe)
+		_, buildErr := buildConfig(tc.spec, "", tc.allowUnsafe, "")
 
 		assert.Equal(t,
 			validateErr == nil, buildErr == nil,


### PR DESCRIPTION
Currently, there is no way to set NextProtos on the tls.Config structs used by Ghostunnel. This change adds a flag to set it.

The use case for me is using a client tunnel to connect to a PostgreSQL server configured to use TLS client certs for auth. Direct TLS connections to PostgreSQL (ones that don't go through whatever handshake PostgreSQL uses to determine if TLS is available) are required to use ALPN to negotiate the use of the "postgresql" protocol. A client that does not do this will have its connections closed by the server.

So without this change, it's not possible to use Ghostunnel as a client tunnel connecting to a PostgreSQL instance like this. With the change, I can pass `--alpn=postgresql` to Ghostunnel and have a working tunnel.