### PR TITLE
Cherry-pick minor changes from 'next'

### DIFF
--- a/certloader/loader.go
+++ b/certloader/loader.go
@@ -50,7 +50,7 @@ func readCertificateFile(path, password, format string) ([]*pem.Block, error) {
 }
 
 // readX509 reads X.509 certificates from a PEM file. Unlike the original certigo
-// implementation, this fails fast on the first unparseable certificate block rather
+// implementation, this fails fast on the first unparsable certificate block rather
 // than accumulating errors and continuing.
 func readX509(path string) ([]*x509.Certificate, error) {
 	pemBlocks, err := readCertificateFile(path, "", "PEM")

--- a/certloader/pkcs11_enabled.go
+++ b/certloader/pkcs11_enabled.go
@@ -98,7 +98,7 @@ func (c *pkcs11Certificate) Reload() error {
 		if old.Leaf == nil || !newPub.Equal(old.Leaf.PublicKey) {
 			return fmt.Errorf("pkcs11: refusing to reload certificate %q: its public key does not match the cached HSM private key", c.certificatePath)
 		}
-		c.logger.Printf("pkcs11: re-using previously cached private key handle from module")
+		c.logger.Printf("pkcs11: reusing previously cached private key handle from module")
 		certAndKey.PrivateKey = old.PrivateKey
 	} else {
 		c.logger.Printf("pkcs11: loading private key for given certificate from module")

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        # Only fail if total project coverage drops by more than this
+        # amount relative to the base. Small fluctuations from test
+        # ordering, platform differences, and flaky-line accounting are
+        # noise and should not fail CI.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # Don't fail on patch (diff) coverage; the project status above is
+        # what gates on meaningful regressions.
+        informational: true
+
+# Wait for all per-platform upload flags before computing a status, so the
+# check reflects merged coverage rather than whichever upload arrived first.
+codecov:
+  notify:
+    wait_for_ci: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true

--- a/main.go
+++ b/main.go
@@ -1117,7 +1117,7 @@ func (env *Environment) serveStatus() error {
 
 	go func() {
 		err := env.statusHTTP.Serve(listener)
-		if err != nil {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Printf("error serving status port: %s", err)
 		}
 	}()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -682,13 +682,20 @@ func isTimeoutError(err error) bool {
 	return (errors.As(err, &netErr) && netErr.Timeout()) || errors.Is(err, context.DeadlineExceeded)
 }
 
+// errWSAEConnReset is WSAECONNRESET on Windows, the equivalent of
+// syscall.ECONNRESET on Unix systems. While syscall.ECONNRESET is defined on
+// Windows as well, it's an APPLICATION_ERROR-based value, not the WSA errno.
+const errWSAEConnReset = syscall.Errno(10054)
+
 func isClosedConnectionError(err error) bool {
 	// Abrupt peer termination (RST / broken pipe) is routine for a proxy —
 	// impatient clients, health checks, and idle keep-alive resets all cause
 	// it — and is not actionable, so treat it the same as an orderly close.
-	// errors.Is unwraps net.OpError, so these match whether or not the error
-	// is wrapped in one. Both errnos are defined on Unix and Windows.
-	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+	// errors.Is unwraps net.OpError, so these match whether or not the error is
+	// wrapped in one. On Windows a socket reset carries the WSA errno
+	// (errWSAEConnReset) rather than the POSIX syscall.ECONNRESET, so match both.
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, errWSAEConnReset) {
 		return true
 	}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -707,6 +707,10 @@ func TestIsClosedConnectionError(t *testing.T) {
 		{name: "net.OpError write EPIPE", err: &net.OpError{Op: "write", Err: syscall.EPIPE}, expected: true},
 		{name: "raw ECONNRESET", err: syscall.ECONNRESET, expected: true},
 		{name: "raw EPIPE", err: syscall.EPIPE, expected: true},
+		// Windows surfaces a socket reset as the WSA errno (10054), which
+		// is different from syscall.ECONNRESET on Windows.
+		{name: "wrapped WSAECONNRESET", err: &net.OpError{Op: "read", Err: os.NewSyscallError("wsarecv", errWSAEConnReset)}, expected: true},
+		{name: "raw WSAECONNRESET", err: errWSAEConnReset, expected: true},
 	}
 
 	for _, tc := range tests {

--- a/tests/common.py
+++ b/tests/common.py
@@ -692,7 +692,7 @@ def start_pebble(work_dir, directory_port, mgmt_port, tls_alpn_port,
     # Skip CAA checks; we have no DNS in tests.
     env['PEBBLE_VA_NOCAACHECK'] = '1'
     # Force a fresh TLS-ALPN-01 challenge on every renewal. Pebble's
-    # default re-uses a still-valid authz 50% of the time, which would
+    # default reuses a still-valid authz 50% of the time, which would
     # let a renewal succeed without actually dialing the listener.
     env['PEBBLE_AUTHZREUSE'] = '0'
 

--- a/tests/test-server-backend-flapping.py
+++ b/tests/test-server-backend-flapping.py
@@ -74,8 +74,12 @@ root = None
 try:
     root = create_default_certs()
 
-    # no backend initially; the target port has nothing listening
-    ghostunnel = start_ghostunnel_server(extra_args=['--enable-pprof'])
+    # no backend initially; the target port has nothing listening. Use a
+    # short connect-timeout so a failed backend dial closes the tunnel well
+    # within the client recv TIMEOUT, even when the loopback silently drops
+    # the SYN (a macOS CI quirk) instead of refusing immediately.
+    ghostunnel = start_ghostunnel_server(
+        extra_args=['--enable-pprof', '--connect-timeout=1s'])
     wait_for_status(lambda info: info.get('message') == 'listening')
     baseline = goroutine_count()
     print_ok('goroutine baseline: {0}'.format(baseline))

--- a/tests/test-server-pkcs11-module.py
+++ b/tests/test-server-pkcs11-module.py
@@ -49,7 +49,7 @@ try:
         "1: client closed -> server closed")
 
     # Trigger a reload to exercise the PKCS#11 cached-key code path
-    # (pkcs11_enabled.go: "re-using previously cached private key handle from
+    # (pkcs11_enabled.go: "reusing previously cached private key handle from
     # module"). Without waiting for the reload to actually finish, a follow-up
     # connection could race and still observe the pre-reload tls.Config. By
     # waiting on the status endpoint's last_reload timestamp we guarantee the

--- a/tls_test.go
+++ b/tls_test.go
@@ -377,7 +377,7 @@ func TestCipherSuitePreference(t *testing.T) {
 	assert.NotNil(t, err, "should not be able to build server TLS config with invalid cipher suite option")
 
 	_, err = buildConfig("", "TLS1.3", false, "")
-	assert.NotNil(t, err, "should not be able to build TLS config wihout cipher suite selection")
+	assert.NotNil(t, err, "should not be able to build TLS config without cipher suite selection")
 
 	conf, err := buildConfig("CHACHA,AES", "TLS1.3", false, "")
 	assert.Nil(t, err, "should be able to build TLS config")


### PR DESCRIPTION
Cherry-pick minor changes from 'next' onto 'master' to make rebases easier; keep feature work on 'next'. 