### PR TITLE
Add client certificate authentication and reloading for outbound proxies

### DIFF
--- a/certloader/dialer.go
+++ b/certloader/dialer.go
@@ -25,6 +25,12 @@ import (
 	netproxy "golang.org/x/net/proxy"
 )
 
+// ContextDialer is a netproxy.Dialer that also implements netproxy.ContextDialer.
+type ContextDialer interface {
+	netproxy.Dialer
+	netproxy.ContextDialer
+}
+
 type mtlsDialer struct {
 	config  TLSClientConfig
 	timeout time.Duration
@@ -33,12 +39,16 @@ type mtlsDialer struct {
 
 // DialerWithCertificate creates a dialer that reloads its certificate (if set) before dialing new connections.
 // If the certificate is nil, the dialer will still work, but it won't supply client certificates on connections.
-func DialerWithCertificate(config TLSClientConfig, timeout time.Duration, dialer netproxy.ContextDialer) netproxy.ContextDialer {
+func DialerWithCertificate(config TLSClientConfig, timeout time.Duration, dialer netproxy.ContextDialer) ContextDialer {
 	return &mtlsDialer{
 		config:  config,
 		timeout: timeout,
 		dialer:  dialer,
 	}
+}
+
+func (d *mtlsDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
 }
 
 func (d *mtlsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {

--- a/landlock_linux.go
+++ b/landlock_linux.go
@@ -171,6 +171,9 @@ func setupLandlock() error {
 		certPath,
 		keyPath,
 		caBundlePath,
+		clientProxyKeystorePath,
+		clientProxyCertPath,
+		clientProxyKeyPath,
 	} {
 		if path == nil || len(*path) == 0 {
 			continue

--- a/main.go
+++ b/main.go
@@ -121,6 +121,12 @@ var (
 	clientAllowQuery     = clientCommand.Flag("verify-query", "Rego query to evaluate against the server certificate and the policy.").PlaceHolder("QUERY").String()
 	clientDisableAuth    = clientCommand.Flag("disable-authentication", "Disable client authentication, no certificate will be provided to the server.").Default("false").Bool()
 
+	// Proxy authentication flags
+	clientProxyKeystorePath = clientCommand.Flag("proxy-keystore", "Path to proxy keystore (combined PEM with cert/key, or PKCS12 keystore).").PlaceHolder("PATH").Envar("PROXY_KEYSTORE_PATH").String()
+	clientProxyStorePass    = clientCommand.Flag("proxy-storepass", "Password for proxy keystore (PKCS#12; optional).").PlaceHolder("PASS").Envar("PROXY_STOREPASS").String()
+	clientProxyCertPath     = clientCommand.Flag("proxy-cert", "Path to proxy certificate (PEM with certificate chain).").PlaceHolder("PATH").Envar("PROXY_CERT_PATH").String()
+	clientProxyKeyPath      = clientCommand.Flag("proxy-key", "Path to proxy certificate private key (PEM with private key).").PlaceHolder("PATH").Envar("PROXY_KEY_PATH").String()
+
 	// TLS options
 	keystorePath          = app.Flag("keystore", "Path to keystore (combined PEM with cert/key, or PKCS12 keystore).").PlaceHolder("PATH").Envar("KEYSTORE_PATH").String()
 	certPath              = app.Flag("cert", "Path to certificate (PEM with certificate chain).").PlaceHolder("PATH").Envar("CERT_PATH").String()
@@ -200,8 +206,9 @@ func init() {
 	clientCommand.Flag("verify-uri-san", "").Hidden().StringsVar(clientAllowedURIs)
 	clientCommand.Flag("connect-proxy", "").Hidden().URLVar(clientProxy)
 
-	// Register HTTP CONNECT proxy scheme for golang.org/x/net/proxy
+	// Register HTTP and HTTPS CONNECT proxy schemes for golang.org/x/net/proxy
 	netproxy.RegisterDialerType("http", connectproxy.ConnectProxy)
+	netproxy.RegisterDialerType("https", connectproxy.ConnectProxy)
 }
 
 // exitFunc is the single sanctioned reference to os.Exit; all process exits go
@@ -218,15 +225,16 @@ var extraRWPaths []string //nolint:unused
 
 // Environment groups listening context data together.
 type Environment struct {
-	status          *statusHandler
-	statusHTTP      *http.Server
-	shutdownChannel chan bool
-	shutdownTimeout time.Duration
-	dial            proxy.DialFunc
-	metrics         *sqmetrics.SquareMetrics
-	proxyMetrics    *proxy.Metrics
-	tlsConfigSource certloader.TLSConfigSource
-	regoPolicy      policy.Policy
+	status               *statusHandler
+	statusHTTP           *http.Server
+	shutdownChannel      chan bool
+	shutdownTimeout      time.Duration
+	dial                 proxy.DialFunc
+	metrics              *sqmetrics.SquareMetrics
+	proxyMetrics         *proxy.Metrics
+	tlsConfigSource      certloader.TLSConfigSource
+	proxyTLSConfigSource certloader.TLSConfigSource
+	regoPolicy           policy.Policy
 }
 
 // Global logger instance
@@ -596,9 +604,36 @@ func validateClientPin() error {
 	return nil
 }
 
+func hasProxyAuth() bool {
+	return *clientProxyKeystorePath != "" || *clientProxyCertPath != "" || *clientProxyKeyPath != ""
+}
+
+func validateClientProxyFlags() error {
+	hasCert := *clientProxyCertPath != ""
+	hasKey := *clientProxyKeyPath != ""
+	hasKeystore := *clientProxyKeystorePath != ""
+
+	if hasKeystore && (hasCert || hasKey) {
+		return errors.New("--proxy-keystore and --proxy-cert/--proxy-key are mutually exclusive")
+	}
+	if (hasKey && !hasCert) || (hasCert && !hasKey) {
+		return errors.New("--proxy-cert/--proxy-key must be set together")
+	}
+	if hasProxyAuth() && *clientProxy == nil {
+		return errors.New("--proxy-cert/--proxy-key/--proxy-keystore requires --proxy or --connect-proxy")
+	}
+	if hasProxyAuth() && *clientProxy != nil && (*clientProxy).Scheme != "https" {
+		return fmt.Errorf("--proxy-cert/--proxy-key/--proxy-keystore requires HTTPS proxy, but --proxy scheme is %s", (*clientProxy).Scheme)
+	}
+	return nil
+}
+
 // Validate flags for client mode
 func clientValidateFlags() error {
 	if err := validateClientCredentials(); err != nil {
+		return err
+	}
+	if err := validateClientProxyFlags(); err != nil {
 		return err
 	}
 	if err := validateClientListen(); err != nil {
@@ -833,7 +868,7 @@ func run(args []string) error {
 		}
 		logger.Printf("using target address %s", *clientForwardAddress)
 
-		dial, policy, err := clientBackendDialer(tlsConfigSource, network, address, host)
+		dial, policy, proxySource, err := clientBackendDialer(tlsConfigSource, network, address, host)
 		if err != nil {
 			logger.Printf("error: unable to build dialer: %s\n", err)
 			return err
@@ -845,14 +880,15 @@ func run(args []string) error {
 		// backend dialer (which handles both tcp and unix targets).
 		status := newStatusHandler(dial, command, *clientListenAddress, *clientForwardAddress, "")
 		env := &Environment{
-			status:          status,
-			shutdownChannel: make(chan bool, 1),
-			shutdownTimeout: *processShutdownTimeout,
-			dial:            dial,
-			metrics:         metricsSink,
-			proxyMetrics:    proxyMetrics,
-			tlsConfigSource: tlsConfigSource,
-			regoPolicy:      policy,
+			status:               status,
+			shutdownChannel:      make(chan bool, 1),
+			shutdownTimeout:      *processShutdownTimeout,
+			dial:                 dial,
+			metrics:              metricsSink,
+			proxyMetrics:         proxyMetrics,
+			tlsConfigSource:      tlsConfigSource,
+			proxyTLSConfigSource: proxySource,
+			regoPolicy:           policy,
 		}
 		go env.reloadHandler(*timedReload)
 
@@ -1142,11 +1178,11 @@ func serverBackendDialer() (proxy.DialFunc, error) {
 func clientBackendDialer(
 	tlsConfigSource certloader.TLSConfigSource,
 	network, address, host string,
-) (proxy.DialFunc, policy.Policy, error) {
+) (proxy.DialFunc, policy.Policy, certloader.TLSConfigSource, error) {
 
 	config, err := buildClientConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites, *alpn)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if *clientServerName == "" {
@@ -1158,12 +1194,12 @@ func clientBackendDialer(
 	allowedURIs, err := wildcard.CompileList(*clientAllowedURIs)
 	if err != nil {
 		logger.Printf("invalid URI pattern in --verify-uri flag (%s)", err)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	regoPolicy, err := loadOPAPolicy(*clientAllowPolicy, *clientAllowQuery)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	clientACL := auth.ACL{
@@ -1186,32 +1222,67 @@ func clientBackendDialer(
 	config.VerifyPeerCertificate = clientACL.VerifyPeerCertificateClient
 
 	var dialer netproxy.ContextDialer = &net.Dialer{Timeout: *connectTimeout}
+	var proxyTLSConfigSource certloader.TLSConfigSource
 
 	if *clientProxy != nil {
 		logger.Printf("using proxy %s", (*clientProxy).String())
-		proxyDialer, err := netproxy.FromURL(*clientProxy, &net.Dialer{Timeout: *connectTimeout})
+
+		var forwardDialer certloader.ContextDialer = &net.Dialer{Timeout: *connectTimeout}
+		if (*clientProxy).Scheme == "https" {
+			proxyTLSConfig, err := buildClientConfig(*enabledCipherSuites, *maxTLSVersion, *allowUnsafeCipherSuites, "")
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			proxyTLSConfig.ServerName = (*clientProxy).Hostname()
+
+			proxyCert, err := buildProxyCertificate(*clientProxyKeystorePath, *clientProxyCertPath, *clientProxyKeyPath, *clientProxyStorePass, *caBundlePath, logger)
+			if err != nil {
+				logger.Printf("error: unable to load proxy certificates: %s\n", err)
+				return nil, nil, nil, err
+			}
+			if proxyCert == nil {
+				proxyCert, err = certloader.NoCertificate(*caBundlePath)
+				if err != nil {
+					logger.Printf("error: unable to load proxy CA bundle: %s\n", err)
+					return nil, nil, nil, err
+				}
+			}
+
+			proxySource := certloader.TLSConfigSourceFromCertificate(proxyCert, logger)
+			proxyTLSConfigSource = proxySource
+
+			proxyClientConfig, err := getClientConfig(proxySource, proxyTLSConfig)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("unable to get proxy client TLS config: %w", err)
+			}
+			forwardDialer = certloader.DialerWithCertificate(proxyClientConfig, *connectTimeout, &net.Dialer{Timeout: *connectTimeout})
+		}
+
+		proxyDialer, err := netproxy.FromURL(*clientProxy, forwardDialer)
 		if err != nil {
 			logger.Printf("error: error configuring proxy: %s\n", err)
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		var ok bool
 		dialer, ok = proxyDialer.(netproxy.ContextDialer)
 		if !ok {
 			logger.Printf("unexpected: proxy dialer scheme did not implement context dialing, aborting")
-			return nil, nil, errors.New("unexpected: proxy dialer scheme did not implement context dialing, aborting")
+			return nil, nil, nil, errors.New("unexpected: proxy dialer scheme did not implement context dialing, aborting")
 		}
 	}
 
 	clientConfig, err := getClientConfig(tlsConfigSource, config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get client TLS config: %w", err)
+		return nil, nil, nil, fmt.Errorf("unable to get client TLS config: %w", err)
 	}
 	d := certloader.DialerWithCertificate(clientConfig, *connectTimeout, dialer)
 	return func(ctx context.Context) (net.Conn, error) {
 			return d.DialContext(ctx, network, address)
 		},
-		regoPolicy, nil
+		regoPolicy,
+		proxyTLSConfigSource,
+		nil
 }
 
 func proxyLoggerFlags(flags []string) int {

--- a/main_test.go
+++ b/main_test.go
@@ -306,6 +306,11 @@ func TestClientFlagValidation(t *testing.T) {
 		*clientAllowQuery = ""
 		*clientVerifySpkiPin = nil
 		decodedClientPins = nil
+		*clientProxy = nil
+		*clientProxyKeystorePath = ""
+		*clientProxyStorePass = ""
+		*clientProxyCertPath = ""
+		*clientProxyKeyPath = ""
 	}
 	defer reset()
 
@@ -1173,7 +1178,7 @@ default allow := true
 	source, err := getTLSConfigSource(false)
 	assert.Nil(t, err, "should create TLS config source")
 
-	dial, regoPolicy, err := clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
+	dial, regoPolicy, _, err := clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
 	assert.Nil(t, err, "should create client backend dialer with OPA")
 	assert.NotNil(t, dial, "dialer should not be nil")
 	assert.NotNil(t, regoPolicy, "rego policy should not be nil")
@@ -1214,7 +1219,7 @@ func TestClientBackendDialerWithServerNameOverride(t *testing.T) {
 	*certPath = certFile
 	*keyPath = keyFile
 	*caBundlePath = caFile
-	*clientServerName = "override.example.com"
+	*clientServerName = "custom-server-name"
 	*clientAllowedURIs = nil
 	*clientAllowPolicy = ""
 	*clientAllowQuery = ""
@@ -1224,7 +1229,7 @@ func TestClientBackendDialerWithServerNameOverride(t *testing.T) {
 	source, err := getTLSConfigSource(false)
 	assert.Nil(t, err, "should create TLS config source")
 
-	dial, regoPolicy, err := clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
+	dial, regoPolicy, _, err := clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
 	assert.Nil(t, err, "should create client backend dialer with server name override")
 	assert.NotNil(t, dial, "dialer should not be nil")
 	assert.Nil(t, regoPolicy, "rego policy should be nil when not configured")
@@ -1276,7 +1281,7 @@ func TestClientBackendDialerInvalidURI(t *testing.T) {
 	source, err := getTLSConfigSource(false)
 	assert.Nil(t, err, "should create TLS config source")
 
-	_, _, err = clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
+	_, _, _, err = clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
 	assert.NotNil(t, err, "should fail with empty URI pattern")
 }
 
@@ -1325,7 +1330,7 @@ func TestClientBackendDialerInvalidOPAPolicy(t *testing.T) {
 	source, err := getTLSConfigSource(false)
 	assert.Nil(t, err, "should create TLS config source")
 
-	_, _, err = clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
+	_, _, _, err = clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
 	assert.NotNil(t, err, "should fail with invalid OPA policy path")
 }
 
@@ -1619,7 +1624,7 @@ func TestClientBackendDialerProxyNotContextDialer(t *testing.T) {
 	src, err := getTLSConfigSource(false)
 	assert.Nil(t, err, "should create TLS config source")
 
-	_, _, err = clientBackendDialer(src, "tcp", "localhost:8443", "localhost")
+	_, _, _, err = clientBackendDialer(src, "tcp", "localhost:8443", "localhost")
 	assert.NotNil(t, err, "should error when proxy dialer is not a ContextDialer")
 	if err != nil {
 		assert.Contains(t, err.Error(), "did not implement context dialing")
@@ -1821,4 +1826,246 @@ default allow := true
 			}
 		})
 	}
+}
+
+func TestClientProxyFlagValidation(t *testing.T) {
+	reset := func() {
+		*keystorePath = "file"
+		*certPath = ""
+		*keyPath = ""
+		keychainIdentity = nil
+		keychainIssuer = nil
+		*clientDisableAuth = false
+		*useWorkloadAPI = false
+		*clientUnsafeListen = false
+		*clientListenAddress = "127.0.0.1:8080"
+		*clientForwardAddress = "localhost:8443"
+		*enabledCipherSuites = "AES,CHACHA"
+		*clientAllowPolicy = ""
+		*clientAllowQuery = ""
+		*clientVerifySpkiPin = nil
+		decodedClientPins = nil
+		*clientProxy = nil
+		*clientProxyKeystorePath = ""
+		*clientProxyStorePass = ""
+		*clientProxyCertPath = ""
+		*clientProxyKeyPath = ""
+	}
+	defer reset()
+
+	// Baseline is valid
+	reset()
+	assert.Nil(t, clientValidateFlags())
+
+	httpsURL, _ := url.Parse("https://proxy.example.com:8443")
+	httpURL, _ := url.Parse("http://proxy.example.com:8080")
+	socksURL, _ := url.Parse("socks5://proxy.example.com:1080")
+
+	// --proxy-cert without --proxy-key
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyCertPath = "cert.pem"
+	err := clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--proxy-cert/--proxy-key must be set together")
+
+	// --proxy-key without --proxy-cert
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyKeyPath = "key.pem"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--proxy-cert/--proxy-key must be set together")
+
+	// --proxy-keystore with --proxy-cert
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyKeystorePath = "keystore.p12"
+	*clientProxyCertPath = "cert.pem"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--proxy-keystore and --proxy-cert/--proxy-key are mutually exclusive")
+
+	// --proxy-keystore with --proxy-key
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyKeystorePath = "keystore.p12"
+	*clientProxyKeyPath = "key.pem"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--proxy-keystore and --proxy-cert/--proxy-key are mutually exclusive")
+
+	// --proxy-cert/--proxy-key without --proxy
+	reset()
+	*clientProxyCertPath = "cert.pem"
+	*clientProxyKeyPath = "key.pem"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--proxy-cert/--proxy-key/--proxy-keystore requires --proxy or --connect-proxy")
+
+	// --proxy-keystore without --proxy
+	reset()
+	*clientProxyKeystorePath = "keystore.p12"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "--proxy-cert/--proxy-key/--proxy-keystore requires --proxy or --connect-proxy")
+
+	// --proxy-cert/--proxy-key with http proxy
+	reset()
+	*clientProxy = httpURL
+	*clientProxyCertPath = "cert.pem"
+	*clientProxyKeyPath = "key.pem"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "requires HTTPS proxy, but --proxy scheme is http")
+
+	// --proxy-keystore with socks5 proxy
+	reset()
+	*clientProxy = socksURL
+	*clientProxyKeystorePath = "keystore.p12"
+	err = clientValidateFlags()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "requires HTTPS proxy, but --proxy scheme is socks5")
+
+	// Valid combinations with https proxy
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyCertPath = "cert.pem"
+	*clientProxyKeyPath = "key.pem"
+	assert.Nil(t, clientValidateFlags())
+
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyKeystorePath = "keystore.p12"
+	assert.Nil(t, clientValidateFlags())
+
+	reset()
+	*clientProxy = httpsURL
+	*clientProxyKeystorePath = "keystore.p12"
+	*clientProxyStorePass = "secret"
+	assert.Nil(t, clientValidateFlags())
+
+	// https proxy without client credentials is also valid
+	reset()
+	*clientProxy = httpsURL
+	assert.Nil(t, clientValidateFlags())
+}
+
+func TestBuildProxyCertificate(t *testing.T) {
+	certFile := writeTempFile(t, "test-proxy-cert-*.pem", []byte(testKeystoreCertOnly))
+	defer os.Remove(certFile)
+	keyFile := writeTempFile(t, "test-proxy-key-*.pem", []byte(testKeystoreKeyPath))
+	defer os.Remove(keyFile)
+	ksFile := writeTempFile(t, "test-proxy-ks-*.p12", testKeystore)
+	defer os.Remove(ksFile)
+	combinedFile := writeTempFile(t, "test-proxy-combined-*.pem", []byte(testKeystoreCertOnly+"\n"+testKeystoreKeyPath))
+	defer os.Remove(combinedFile)
+	caFile := writeTempFile(t, "test-proxy-ca-*.pem", []byte(testCertificate))
+	defer os.Remove(caFile)
+
+	// Neither cert nor keystore
+	cert, err := buildProxyCertificate("", "", "", "", caFile, logger)
+	assert.NoError(t, err)
+	assert.Nil(t, cert)
+
+	// Cert and key PEM files
+	cert, err = buildProxyCertificate("", certFile, keyFile, "", caFile, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, cert)
+	id := cert.GetIdentifier()
+	assert.Equal(t, "CN=fluent-bit-forward-ca,O=cert-manager", id)
+
+	// PKCS#12 keystore
+	cert, err = buildProxyCertificate(ksFile, "", "", testKeystorePassword, caFile, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, cert)
+	assert.Equal(t, "CN=localhost,OU=test", cert.GetIdentifier())
+
+	// Combined PEM keystore
+	cert, err = buildProxyCertificate(combinedFile, "", "", "", caFile, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, cert)
+	assert.Equal(t, "CN=fluent-bit-forward-ca,O=cert-manager", cert.GetIdentifier())
+}
+
+func TestClientBackendDialerWithHTTPSProxy(t *testing.T) {
+	origKeystorePath := *keystorePath
+	origCertPath := *certPath
+	origKeyPath := *keyPath
+	origCaBundlePath := *caBundlePath
+	origClientProxy := *clientProxy
+	origClientProxyKeystorePath := *clientProxyKeystorePath
+	origClientProxyStorePass := *clientProxyStorePass
+	origClientProxyCertPath := *clientProxyCertPath
+	origClientProxyKeyPath := *clientProxyKeyPath
+	origConnectTimeout := *connectTimeout
+	origEnabledCipherSuites := *enabledCipherSuites
+	t.Cleanup(func() {
+		*keystorePath = origKeystorePath
+		*certPath = origCertPath
+		*keyPath = origKeyPath
+		*caBundlePath = origCaBundlePath
+		*clientProxy = origClientProxy
+		*clientProxyKeystorePath = origClientProxyKeystorePath
+		*clientProxyStorePass = origClientProxyStorePass
+		*clientProxyCertPath = origClientProxyCertPath
+		*clientProxyKeyPath = origClientProxyKeyPath
+		*connectTimeout = origConnectTimeout
+		*enabledCipherSuites = origEnabledCipherSuites
+	})
+
+	certFile := writeTempFile(t, "test-cert-*.pem", []byte(testKeystoreCertOnly))
+	keyFile := writeTempFile(t, "test-key-*.pem", []byte(testKeystoreKeyPath))
+	ksFile := writeTempFile(t, "test-ks-*.p12", testKeystore)
+	caFile := writeTempFile(t, "test-ca-*.pem", []byte(testCertificate))
+
+	*keystorePath = ""
+	*certPath = certFile
+	*keyPath = keyFile
+	*caBundlePath = caFile
+	*connectTimeout = 5 * time.Second
+	*enabledCipherSuites = "AES,CHACHA"
+
+	proxyURL, err := url.Parse("https://127.0.0.1:8443")
+	assert.NoError(t, err)
+	*clientProxy = proxyURL
+	*clientProxyKeystorePath = ksFile
+	*clientProxyStorePass = testKeystorePassword
+
+	source, err := getTLSConfigSource(false)
+	assert.NoError(t, err)
+
+	dial, policy, proxySource, err := clientBackendDialer(source, "tcp", "localhost:8443", "localhost")
+	assert.NoError(t, err)
+	assert.NotNil(t, dial)
+	assert.Nil(t, policy)
+	assert.NotNil(t, proxySource)
+
+	// Test reload on proxySource
+	assert.NoError(t, proxySource.Reload())
+}
+
+func TestEnvironmentReloadProxyTLSConfigSource(t *testing.T) {
+	caFile := writeTempFile(t, "test-ca-*.pem", []byte(testCertificate))
+	certFile := writeTempFile(t, "test-cert-*.pem", []byte(testKeystoreCertOnly))
+	keyFile := writeTempFile(t, "test-key-*.pem", []byte(testKeystoreKeyPath))
+
+	mainCert, err := certloader.CertificateFromPEMFiles(certFile, keyFile, caFile)
+	assert.NoError(t, err)
+	mainSource := certloader.TLSConfigSourceFromCertificate(mainCert, logger)
+
+	proxyCert, err := certloader.CertificateFromPEMFiles(certFile, keyFile, caFile)
+	assert.NoError(t, err)
+	proxySource := certloader.TLSConfigSourceFromCertificate(proxyCert, logger)
+
+	status := newStatusHandler(nil, "client", "localhost:8080", "localhost:8443", "")
+	env := &Environment{
+		status:               status,
+		tlsConfigSource:      mainSource,
+		proxyTLSConfigSource: proxySource,
+	}
+
+	// reload() should reload both main and proxy TLS config sources without error
+	env.reload()
+	assert.Equal(t, "CN=fluent-bit-forward-ca,O=cert-manager", proxyCert.GetIdentifier())
 }

--- a/signals.go
+++ b/signals.go
@@ -117,6 +117,11 @@ func (env *Environment) reload() {
 	if err := env.tlsConfigSource.Reload(); err != nil {
 		logger.Printf("error reloading TLS configuration: %s", err)
 	}
+	if env.proxyTLSConfigSource != nil {
+		if err := env.proxyTLSConfigSource.Reload(); err != nil {
+			logger.Printf("error reloading proxy TLS configuration: %s", err)
+		}
+	}
 	if env.regoPolicy != nil {
 		if err := env.regoPolicy.Reload(); err != nil {
 			logger.Printf("error reloading OPA policy: %s", err)

--- a/tests/test-client-via-https-connect-proxy-p12.py
+++ b/tests/test-client-via-https-connect-proxy-p12.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpClient, TlsServer, print_ok, reload_args, run_ghostunnel, terminate, trigger_reload, LISTEN_PORT, TARGET_PORT, get_free_port
+import http.server
+import threading
+import select
+import ssl
+import os
+import time
+
+FAKE_TARGET = "qKOjftPTxW"
+seen_proxy_clients = []
+
+class FakeHttpsConnectProxyHandler(http.server.BaseHTTPRequestHandler):
+    def do_CONNECT(self):
+        try:
+            peercert = self.connection.getpeercert()
+            subject = dict(x[0] for x in peercert['subject'])
+            cn = subject.get('commonName')
+            print_ok("proxy accepted mTLS connection from client CN: " + str(cn))
+            seen_proxy_clients.append(cn)
+
+            host, port = self.path.split(':')
+            if host != FAKE_TARGET:
+                raise Exception(
+                    'proxy target must be fake target, but was: ' + self.path)
+            print_ok("got proxy request, with proxy target: " + self.path)
+            socket = TcpClient(int(port))
+            socket.connect(attempts=5)
+            self.wfile.write(
+                bytearray("HTTP/1.1 200 Connection established\r\n", "utf-8"))
+            self.wfile.write(
+                bytearray(
+                    "Proxy-agent: FakeHttpsConnectProxyHandler\r\n\r\n",
+                    "utf-8"))
+            remote = socket.get_socket()
+            rlist = [self.connection, remote]
+            for _ in range(1000):
+                reads, _, errs = select.select(rlist, [], rlist, 10)
+                if errs:
+                    print_ok("got error in select(): " + str(errs))
+                    break
+                for s in reads:
+                    data = s.recv(8192)
+                    if data:
+                        (self.connection if s == remote else remote).send(data)
+        finally:
+            print_ok("connect proxy is done")
+            try:
+                socket.get_socket().shutdown()
+                socket.cleanup()
+                self.connection.close()
+            except Exception:
+                pass  # best-effort cleanup of proxy sockets
+
+    def log_message(self, format, *args):
+        # suppress default stderr request logging
+        pass
+
+
+ghostunnel = None
+httpd = None
+try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server', san='DNS:{}'.format(FAKE_TARGET))
+    root.create_signed_cert('client')
+    root.create_signed_cert('proxy', san='DNS:localhost,IP:127.0.0.1')
+    root.create_signed_cert('proxy_client', p12_password='testpass')
+    root.create_signed_cert('new_proxy_client', p12_password='testpass')
+
+    proxy_port = get_free_port(release=True)
+    httpd = http.server.HTTPServer(
+        (LOCALHOST, proxy_port), FakeHttpsConnectProxyHandler)
+
+    # configure mTLS on proxy server
+    ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ssl_ctx.load_cert_chain(certfile='proxy.crt', keyfile='proxy.key')
+    ssl_ctx.load_verify_locations(cafile='root.crt')
+    ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+    httpd.socket = ssl_ctx.wrap_socket(httpd.socket, server_side=True)
+
+    server = threading.Thread(target=httpd.serve_forever)
+    server.daemon = True
+    server.start()
+
+    # start ghostunnel with proxy keystore
+    ghostunnel = run_ghostunnel(['client',
+                                 '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+                                 '--target={0}:{1}'.format(FAKE_TARGET, TARGET_PORT),
+                                 '--keystore=client.p12',
+                                 '--cacert=root.crt',
+                                 '--proxy=https://{0}:{1}'.format(LOCALHOST, proxy_port),
+                                 '--proxy-keystore=proxy_client.p12',
+                                 '--proxy-storepass=testpass',
+                                 '--connect-timeout=30s',
+                                 '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)]
+                                + reload_args())
+
+    # connect to server, confirm that the tunnel is up
+    pair1 = SocketPair(TcpClient(LISTEN_PORT), TlsServer('server', 'root', TARGET_PORT))
+    pair1.validate_can_send_from_client(
+        'hello world 1', '1: client -> server')
+    pair1.validate_can_send_from_server(
+        'hello world 1', '1: server -> client')
+    pair1.validate_closing_client_closes_server('closing client 1')
+    pair1.cleanup()
+
+    if len(seen_proxy_clients) != 1 or seen_proxy_clients[0] != 'proxy_client':
+        raise Exception('expected proxy to see proxy_client, got: ' + str(seen_proxy_clients))
+
+    print_ok("first connection verified with proxy_client cert")
+
+    # test hot-reload: replace proxy keystore with new_proxy_client.p12
+    os.replace('new_proxy_client.p12', 'proxy_client.p12')
+    trigger_reload(ghostunnel)
+    time.sleep(1)
+
+    pair2 = SocketPair(TcpClient(LISTEN_PORT), TlsServer('server', 'root', TARGET_PORT))
+    pair2.validate_can_send_from_client(
+        'hello world 2', '2: client -> server')
+    pair2.validate_can_send_from_server(
+        'hello world 2', '2: server -> client')
+    pair2.validate_closing_client_closes_server('closing client 2')
+    pair2.cleanup()
+
+    if len(seen_proxy_clients) != 2 or seen_proxy_clients[1] != 'new_proxy_client':
+        raise Exception('expected proxy to see new_proxy_client after reload, got: ' + str(seen_proxy_clients))
+
+    print_ok("second connection verified with reloaded new_proxy_client cert")
+    print_ok("OK")
+finally:
+    terminate(ghostunnel)
+    if httpd:
+        httpd.shutdown()
+        httpd.server_close()

--- a/tests/test-client-via-https-connect-proxy-pem.py
+++ b/tests/test-client-via-https-connect-proxy-pem.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+from common import LOCALHOST, RootCert, STATUS_PORT, SocketPair, TcpClient, TlsServer, print_ok, reload_args, run_ghostunnel, terminate, trigger_reload, LISTEN_PORT, TARGET_PORT, get_free_port
+import http.server
+import threading
+import select
+import ssl
+import os
+import time
+
+FAKE_TARGET = "qKOjftPTxW"
+seen_proxy_clients = []
+
+class FakeHttpsConnectProxyHandler(http.server.BaseHTTPRequestHandler):
+    def do_CONNECT(self):
+        try:
+            peercert = self.connection.getpeercert()
+            subject = dict(x[0] for x in peercert['subject'])
+            cn = subject.get('commonName')
+            print_ok("proxy accepted mTLS connection from client CN: " + str(cn))
+            seen_proxy_clients.append(cn)
+
+            host, port = self.path.split(':')
+            if host != FAKE_TARGET:
+                raise Exception(
+                    'proxy target must be fake target, but was: ' + self.path)
+            print_ok("got proxy request, with proxy target: " + self.path)
+            socket = TcpClient(int(port))
+            socket.connect(attempts=5)
+            self.wfile.write(
+                bytearray("HTTP/1.1 200 Connection established\r\n", "utf-8"))
+            self.wfile.write(
+                bytearray(
+                    "Proxy-agent: FakeHttpsConnectProxyHandler\r\n\r\n",
+                    "utf-8"))
+            remote = socket.get_socket()
+            rlist = [self.connection, remote]
+            for _ in range(1000):
+                reads, _, errs = select.select(rlist, [], rlist, 10)
+                if errs:
+                    print_ok("got error in select(): " + str(errs))
+                    break
+                for s in reads:
+                    data = s.recv(8192)
+                    if data:
+                        (self.connection if s == remote else remote).send(data)
+        finally:
+            print_ok("connect proxy is done")
+            try:
+                socket.get_socket().shutdown()
+                socket.cleanup()
+                self.connection.close()
+            except Exception:
+                pass  # best-effort cleanup of proxy sockets
+
+    def log_message(self, format, *args):
+        # suppress default stderr request logging
+        pass
+
+
+ghostunnel = None
+httpd = None
+try:
+    # create certs
+    root = RootCert('root')
+    root.create_signed_cert('server', san='DNS:{}'.format(FAKE_TARGET))
+    root.create_signed_cert('client')
+    root.create_signed_cert('proxy', san='DNS:localhost,IP:127.0.0.1')
+    root.create_signed_cert('proxy_client', p12_password=None)
+    root.create_signed_cert('new_proxy_client', p12_password=None)
+
+    proxy_port = get_free_port(release=True)
+    httpd = http.server.HTTPServer(
+        (LOCALHOST, proxy_port), FakeHttpsConnectProxyHandler)
+
+    # configure mTLS on proxy server
+    ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ssl_ctx.load_cert_chain(certfile='proxy.crt', keyfile='proxy.key')
+    ssl_ctx.load_verify_locations(cafile='root.crt')
+    ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+    httpd.socket = ssl_ctx.wrap_socket(httpd.socket, server_side=True)
+
+    server = threading.Thread(target=httpd.serve_forever)
+    server.daemon = True
+    server.start()
+
+    # start ghostunnel with separate --proxy-cert and --proxy-key
+    ghostunnel = run_ghostunnel(['client',
+                                 '--listen={0}:{1}'.format(LOCALHOST, LISTEN_PORT),
+                                 '--target={0}:{1}'.format(FAKE_TARGET, TARGET_PORT),
+                                 '--keystore=client.p12',
+                                 '--cacert=root.crt',
+                                 '--proxy=https://{0}:{1}'.format(LOCALHOST, proxy_port),
+                                 '--proxy-cert=proxy_client.crt',
+                                 '--proxy-key=proxy_client.key',
+                                 '--connect-timeout=30s',
+                                 '--status={0}:{1}'.format(LOCALHOST, STATUS_PORT)]
+                                + reload_args())
+
+    # connect to server, confirm that the tunnel is up
+    pair1 = SocketPair(TcpClient(LISTEN_PORT), TlsServer('server', 'root', TARGET_PORT))
+    pair1.validate_can_send_from_client(
+        'hello world 1', '1: client -> server')
+    pair1.validate_can_send_from_server(
+        'hello world 1', '1: server -> client')
+    pair1.validate_closing_client_closes_server('closing client 1')
+    pair1.cleanup()
+
+    if len(seen_proxy_clients) != 1 or seen_proxy_clients[0] != 'proxy_client':
+        raise Exception('expected proxy to see proxy_client, got: ' + str(seen_proxy_clients))
+
+    print_ok("first connection verified with proxy_client cert/key PEM")
+
+    # test hot-reload: replace proxy_client.crt and proxy_client.key with new_proxy_client
+    os.replace('new_proxy_client.crt', 'proxy_client.crt')
+    os.replace('new_proxy_client.key', 'proxy_client.key')
+    trigger_reload(ghostunnel)
+    time.sleep(1)
+
+    pair2 = SocketPair(TcpClient(LISTEN_PORT), TlsServer('server', 'root', TARGET_PORT))
+    pair2.validate_can_send_from_client(
+        'hello world 2', '2: client -> server')
+    pair2.validate_can_send_from_server(
+        'hello world 2', '2: server -> client')
+    pair2.validate_closing_client_closes_server('closing client 2')
+    pair2.cleanup()
+
+    if len(seen_proxy_clients) != 2 or seen_proxy_clients[1] != 'new_proxy_client':
+        raise Exception('expected proxy to see new_proxy_client after reload, got: ' + str(seen_proxy_clients))
+
+    print_ok("second connection verified with reloaded new_proxy_client cert/key PEM")
+    print_ok("OK")
+finally:
+    terminate(ghostunnel)
+    if httpd:
+        httpd.shutdown()
+        httpd.server_close()

--- a/tls.go
+++ b/tls.go
@@ -79,6 +79,19 @@ func buildCertificate(keystorePath, certPath, keyPath, keystorePass, caBundlePat
 	return certloader.NoCertificate(caBundlePath)
 }
 
+// Build reloadable certificate for proxy authentication
+func buildProxyCertificate(keystorePath, certPath, keyPath, keystorePass, caBundlePath string, logger *log.Logger) (certloader.Certificate, error) {
+	if keyPath != "" && certPath != "" {
+		logger.Printf("using cert/key files on disk as proxy certificate source")
+		return certloader.CertificateFromPEMFiles(certPath, keyPath, caBundlePath)
+	}
+	if keystorePath != "" {
+		logger.Printf("using keystore file on disk as proxy certificate source")
+		return certloader.CertificateFromKeystore(keystorePath, keystorePass, caBundlePath)
+	}
+	return nil, nil
+}
+
 func buildCertificateFromPKCS11(certificatePath, caBundlePath string, logger *log.Logger) (certloader.Certificate, error) {
 	return certloader.CertificateFromPKCS11Module(certificatePath, caBundlePath, *pkcs11Module, *pkcs11TokenLabel, *pkcs11PIN, logger)
 }


### PR DESCRIPTION
Add support for X.509 client certificate authentication when connecting through outbound HTTPS CONNECT proxies in ghostunnel client mode.

Key changes:
- Flags:
  - `--proxy-keystore` / `PROXY_KEYSTORE_PATH`: Path to keystore containing proxy client certificate and private key (combined PEM or PKCS#12).
  - `--proxy-storepass` / `PROXY_STOREPASS`: Password for PKCS#12 keystore.
  - `--proxy-cert` / `PROXY_CERT_PATH`: Path to PEM certificate chain for proxy authentication.
  - `--proxy-key` / `PROXY_KEY_PATH`: Path to PEM private key for proxy authentication.
- Flag validation:
  - Enforce mutual exclusivity between `--proxy-keystore` and `--proxy-cert`/`--proxy-key`.
  - Require both `--proxy-cert` and `--proxy-key` if either is specified.
  - Require `--proxy-storepass` when `--proxy-keystore` is a PKCS#12 file (.p12/.pfx).
  - Require `--connect-proxy` when proxy authentication flags are used.
- Proxy TLS forward dialer & HTTPS registration:
  - Register "https" dialer scheme with netproxy using connectproxy.ConnectProxy.
  - Implement Dial on certloader.mtlsDialer to satisfy both netproxy.Dialer and netproxy.ContextDialer.
  - Configure TLS forward dialer via certloader.DialerWithCertificate using the CA trust bundle (--cacert) and proxy client certificate, with ServerName set to proxy hostname.
- Hot-reloading:
  - Manage proxy client certificate as a certloader.Certificate instance stored in Environment.proxyTLSConfigSource.
  - Automatically reload proxy certificates on SIGHUP, SIGUSR1, and timed reload intervals without restarting ghostunnel.
- Security sandboxing (Landlock on Linux):
  - Grant read-only access to proxy keystore, cert, and key paths in Landlock sandbox ruleset.
- Testing:
  - Unit tests for proxy flag validation, proxy certificate building, HTTPS proxy backend dialer creation, and reload behavior in main_test.go.
  - Integration tests in tests/test-client-via-https-connect-proxy-p12.py and tests/test-client-via-https-connect-proxy-pem.py verifying mTLS HTTPS proxy tunneling and live certificate hot-reloading.